### PR TITLE
Add daily average metrics and score to today summary

### DIFF
--- a/raterhub-tracker/app/main.py
+++ b/raterhub-tracker/app/main.py
@@ -839,12 +839,16 @@ def build_day_summary(
             total_questions=0,
             total_active_seconds=0.0,
             total_active_mmss="00:00",
+            avg_active_seconds=0.0,
+            avg_active_mmss="00:00",
+            daily_score=0,
             sessions=[],
         )
 
     total_sessions = 0
     total_questions_all = 0
     total_active_all = 0.0
+    total_score_weighted = 0.0
     items: List[TodaySessionItem] = []
 
     for s in sessions:
@@ -887,6 +891,7 @@ def build_day_summary(
 
         total_questions_all += count
         total_active_all += total_active
+        total_score_weighted += pace["score"] * count
 
         items.append(
             TodaySessionItem(
@@ -904,6 +909,15 @@ def build_day_summary(
             )
         )
 
+    avg_active_day = (
+        total_active_all / total_questions_all if total_questions_all else 0.0
+    )
+    daily_score = (
+        round(total_score_weighted / total_questions_all)
+        if total_questions_all
+        else 0
+    )
+
     return TodaySummary(
         date=local_start,  # stored as local midnight in user's TZ
         user_external_id=user.email,
@@ -911,6 +925,9 @@ def build_day_summary(
         total_questions=total_questions_all,
         total_active_seconds=total_active_all,
         total_active_mmss=format_hhmm_or_mmss_for_dashboard(total_active_all),
+        avg_active_seconds=avg_active_day,
+        avg_active_mmss=format_hhmm_or_mmss_for_dashboard(avg_active_day),
+        daily_score=daily_score,
         sessions=items,
     )
 

--- a/raterhub-tracker/app/models.py
+++ b/raterhub-tracker/app/models.py
@@ -94,6 +94,10 @@ class TodaySummary(BaseModel):
     total_active_seconds: float
     total_active_mmss: str
 
+    avg_active_seconds: float
+    avg_active_mmss: str
+    daily_score: int
+
     sessions: list[TodaySessionItem]
 
 class Token(BaseModel):

--- a/raterhub-tracker/app/templates/today.html
+++ b/raterhub-tracker/app/templates/today.html
@@ -344,6 +344,30 @@
                 Sum of focused time on tasks (pauses excluded)
             </div>
         </div>
+
+        <div class="summary-card">
+            <div class="summary-label">Avg Time / Question</div>
+            <div class="summary-value">{{ summary.avg_active_mmss }}</div>
+            <div class="summary-extra">
+                Across all questions today
+            </div>
+        </div>
+
+        <div class="summary-card">
+            <div class="summary-label">Daily Score</div>
+            <div class="summary-value">
+                {% set score = summary.daily_score or 0 %}
+                <span class="score-pill
+                    {% if score >= 80 %}score-good
+                    {% elif score >= 50 %}score-mid
+                    {% else %}score-bad
+                    {% endif %}
+                ">{{ score }}/100</span>
+            </div>
+            <div class="summary-extra">
+                Weighted by question count
+            </div>
+        </div>
     </div>
 
     <!-- Per-session details -->


### PR DESCRIPTION
## Summary
- add daily average time and score fields to the Today summary model and data builder
- calculate weighted daily score and average active time per question in the day summary
- display new average time and daily score cards on the today dashboard

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a47ed3aac832e84cd5b20be5a4428)