### PR TITLE
Add daily pace summary details

### DIFF
--- a/raterhub-tracker/app/main.py
+++ b/raterhub-tracker/app/main.py
@@ -832,6 +832,7 @@ def build_day_summary(
     )
 
     if not sessions:
+        daily_pace = compute_pace(0.0, 0.0)
         return TodaySummary(
             date=local_start,  # report date as local midnight
             user_external_id=user.email,
@@ -841,8 +842,10 @@ def build_day_summary(
             total_active_mmss="00:00",
             avg_active_seconds=0.0,
             avg_active_mmss="00:00",
-            daily_pace_label="No questions",
-            daily_pace_emoji="😴",
+            daily_pace_label=daily_pace["pace_label"],
+            daily_pace_emoji=daily_pace["pace_emoji"],
+            daily_pace_score=daily_pace["score"],
+            daily_pace_ratio=daily_pace["ratio"],
             sessions=[],
         )
 
@@ -919,11 +922,7 @@ def build_day_summary(
         if total_questions_all
         else 0.0
     )
-    daily_pace = (
-        compute_pace(avg_active_day, avg_target_minutes)
-        if total_questions_all
-        else {"pace_label": "No questions", "pace_emoji": "😴"}
-    )
+    daily_pace = compute_pace(avg_active_day, avg_target_minutes)
 
     return TodaySummary(
         date=local_start,  # stored as local midnight in user's TZ
@@ -936,6 +935,8 @@ def build_day_summary(
         avg_active_mmss=format_hhmm_or_mmss_for_dashboard(avg_active_day),
         daily_pace_label=daily_pace["pace_label"],
         daily_pace_emoji=daily_pace["pace_emoji"],
+        daily_pace_score=daily_pace["score"],
+        daily_pace_ratio=daily_pace["ratio"],
         sessions=items,
     )
 

--- a/raterhub-tracker/app/models.py
+++ b/raterhub-tracker/app/models.py
@@ -98,6 +98,8 @@ class TodaySummary(BaseModel):
     avg_active_mmss: str
     daily_pace_label: str
     daily_pace_emoji: str
+    daily_pace_score: int
+    daily_pace_ratio: float
 
     sessions: list[TodaySessionItem]
 

--- a/raterhub-tracker/app/templates/today.html
+++ b/raterhub-tracker/app/templates/today.html
@@ -354,7 +354,7 @@
         </div>
 
         <div class="summary-card">
-            <div class="summary-label">Daily Pace</div>
+            <div class="summary-label">Daily pace vs target</div>
             <div class="summary-value">
                 <span class="pace-chip">{{ summary.daily_pace_emoji }} {{ summary.daily_pace_label }}</span>
             </div>


### PR DESCRIPTION
## Summary
- derive daily pace data via compute_pace when building day summaries
- expose daily pace metadata on TodaySummary responses
- surface a daily pace vs target chip in the dashboard summary cards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a4b158f48832eb165587967182ab8)