### PR TITLE
Add hourly activity sparkline to dashboard

### DIFF
--- a/raterhub-tracker/app/main.py
+++ b/raterhub-tracker/app/main.py
@@ -832,6 +832,8 @@ def build_day_summary(
     )
 
     if not sessions:
+        hourly_buckets = [0.0 for _ in range(24)]
+        daily_pace = compute_pace(0.0, 0.0)
         return TodaySummary(
             date=local_start,  # report date as local midnight
             user_external_id=user.email,
@@ -841,8 +843,11 @@ def build_day_summary(
             total_active_mmss="00:00",
             avg_active_seconds=0.0,
             avg_active_mmss="00:00",
-            daily_pace_label="No questions",
-            daily_pace_emoji="😴",
+            daily_pace_label=daily_pace["pace_label"],
+            daily_pace_emoji=daily_pace["pace_emoji"],
+            daily_pace_score=daily_pace["score"],
+            daily_pace_ratio=daily_pace["ratio"],
+            hourly_active_seconds=hourly_buckets,
             sessions=[],
         )
 
@@ -850,6 +855,7 @@ def build_day_summary(
     total_questions_all = 0
     total_active_all = 0.0
     total_target_minutes_weighted = 0.0
+    hourly_active_seconds = [0.0 for _ in range(24)]
     items: List[TodaySessionItem] = []
 
     for s in sessions:
@@ -895,6 +901,11 @@ def build_day_summary(
         total_active_all += total_active
         total_target_minutes_weighted += target_minutes * count
 
+        for q in qs:
+            q_local_start = to_user_local(q.started_at, user)
+            if q_local_start.date() == local_start.date():
+                hourly_active_seconds[q_local_start.hour] += q.active_seconds
+
         items.append(
             TodaySessionItem(
                 session_id=s.public_id,
@@ -919,11 +930,7 @@ def build_day_summary(
         if total_questions_all
         else 0.0
     )
-    daily_pace = (
-        compute_pace(avg_active_day, avg_target_minutes)
-        if total_questions_all
-        else {"pace_label": "No questions", "pace_emoji": "😴"}
-    )
+    daily_pace = compute_pace(avg_active_day, avg_target_minutes)
 
     return TodaySummary(
         date=local_start,  # stored as local midnight in user's TZ
@@ -936,6 +943,9 @@ def build_day_summary(
         avg_active_mmss=format_hhmm_or_mmss_for_dashboard(avg_active_day),
         daily_pace_label=daily_pace["pace_label"],
         daily_pace_emoji=daily_pace["pace_emoji"],
+        daily_pace_score=daily_pace["score"],
+        daily_pace_ratio=daily_pace["ratio"],
+        hourly_active_seconds=hourly_active_seconds,
         sessions=items,
     )
 

--- a/raterhub-tracker/app/models.py
+++ b/raterhub-tracker/app/models.py
@@ -98,6 +98,9 @@ class TodaySummary(BaseModel):
     avg_active_mmss: str
     daily_pace_label: str
     daily_pace_emoji: str
+    daily_pace_score: int
+    daily_pace_ratio: float
+    hourly_active_seconds: list[float]
 
     sessions: list[TodaySessionItem]
 

--- a/raterhub-tracker/app/templates/today.html
+++ b/raterhub-tracker/app/templates/today.html
@@ -119,6 +119,37 @@
             max-width: 100%;
         }
 
+        .sparkline-grid {
+            display: grid;
+            grid-template-columns: repeat(24, 1fr);
+            gap: 2px;
+            align-items: end;
+            height: 52px;
+            margin-top: 8px;
+        }
+
+        .sparkline-col {
+            width: 100%;
+            background: linear-gradient(180deg, #6c5ce7, #a66bff);
+            border-radius: 3px 3px 0 0;
+            min-height: 4px;
+            opacity: 0.85;
+        }
+
+        .sparkline-col.is-zero {
+            background: #e6ddff;
+            opacity: 0.6;
+            min-height: 3px;
+        }
+
+        .sparkline-axis {
+            display: flex;
+            justify-content: space-between;
+            font-size: 11px;
+            color: var(--text-muted);
+            margin-top: 4px;
+        }
+
         .section-title {
             font-size: 16px;
             color: var(--accent-dark);
@@ -354,12 +385,39 @@
         </div>
 
         <div class="summary-card">
-            <div class="summary-label">Daily Pace</div>
+            <div class="summary-label">Daily pace vs target</div>
             <div class="summary-value">
                 <span class="pace-chip">{{ summary.daily_pace_emoji }} {{ summary.daily_pace_label }}</span>
             </div>
             <div class="summary-extra">
                 Based on average time vs target
+            </div>
+        </div>
+
+        <div class="summary-card">
+            <div class="summary-label">Hourly activity</div>
+            {% set hourly = summary.hourly_active_seconds or [] %}
+            {% set max_value = (hourly | max) if hourly else 0 %}
+            <div class="summary-value" aria-label="Sparkline of hourly active seconds">
+                <div class="sparkline-grid">
+                    {% for value in hourly %}
+                        {% set raw_height = (value / max_value * 100) if max_value > 0 else 0 %}
+                        {% set bar_height = raw_height if raw_height > 6 else (6 if value > 0 else 0) %}
+                        <div
+                            class="sparkline-col{% if value == 0 %} is-zero{% endif %}"
+                            style="height: {{ bar_height }}%;"
+                            title="{{ '%02d' % loop.index0 }}: {{ value|round(0) }}s active"
+                        ></div>
+                    {% endfor %}
+                </div>
+                <div class="sparkline-axis">
+                    <span>00h</span>
+                    <span>12h</span>
+                    <span>24h</span>
+                </div>
+            </div>
+            <div class="summary-extra">
+                Active seconds per local hour{% if user_timezone %} ({{ user_timezone }}){% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- capture hourly active seconds in daily summaries for sparkline rendering
- expose hourly buckets via the TodaySummary response
- visualize hourly activity on the Today dashboard with a sparkline chip

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a4b158f48832eb165587967182ab8)