### PR TITLE
Show logged-in user in dashboard navigation

### DIFF
--- a/raterhub-tracker/app/main.py
+++ b/raterhub-tracker/app/main.py
@@ -794,7 +794,11 @@ def dashboard_session(
     summary = build_session_summary(db, current_user, session_public_id)
     return templates.TemplateResponse(
         "session.html",
-        {"request": request, "summary": summary},
+        {
+            "request": request,
+            "summary": summary,
+            "current_user_email": getattr(current_user, "email", None),
+        },
     )
 
 # ============================================================
@@ -1012,6 +1016,7 @@ def dashboard_today(
             "summary": summary,
             "selected_date": selected_date_str,
             "user_timezone": getattr(current_user, "timezone", None),
+            "current_user_email": getattr(current_user, "email", None),
         },
     )
 

--- a/raterhub-tracker/app/templates/session.html
+++ b/raterhub-tracker/app/templates/session.html
@@ -32,6 +32,37 @@
             margin: 0 auto;
         }
 
+        .nav {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 16px;
+        }
+        .nav-logo {
+            font-weight: 600;
+            color: #4b3b86;
+        }
+        .nav-right {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .nav-right a {
+            font-size: 13px;
+            color: #6c5ce7;
+            text-decoration: none;
+        }
+        .nav-right a:hover {
+            text-decoration: underline;
+        }
+        .nav-user {
+            font-size: 12px;
+            color: #4b3b86;
+            background: #e9e3ff;
+            padding: 6px 10px;
+            border-radius: 999px;
+        }
+
         header {
             margin-bottom: 20px;
         }
@@ -264,6 +295,18 @@
     </style>
 </head>
 <body>
+<div class="nav">
+    <div class="nav-left">
+        <span class="nav-logo">💜 RaterHub Tracker</span>
+    </div>
+    <div class="nav-right">
+        <span class="nav-user">Logged in as {{ current_user_email or 'Unknown user' }}</span>
+        <a href="/dashboard/today">Today</a>
+        <a href="/admin/dashboard">Admin</a>
+                <a href="/profile">Preferences</a>
+        <a href="/logout">Logout</a>
+    </div>
+</div>
 <div class="page">
     <header>
         <a href="/dashboard/today" class="back-link">← Back to today’s metrics</a>

--- a/raterhub-tracker/app/templates/today.html
+++ b/raterhub-tracker/app/templates/today.html
@@ -42,14 +42,25 @@
             font-weight: 600;
             color: #4b3b86;
         }
+        .nav-right {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
         .nav-right a {
-            margin-left: 12px;
             font-size: 13px;
             color: #6c5ce7;
             text-decoration: none;
         }
         .nav-right a:hover {
             text-decoration: underline;
+        }
+        .nav-user {
+            font-size: 12px;
+            color: #4b3b86;
+            background: #e9e3ff;
+            padding: 6px 10px;
+            border-radius: 999px;
         }
 
         header {
@@ -309,9 +320,10 @@
         <span class="nav-logo">💜 RaterHub Tracker</span>
     </div>
     <div class="nav-right">
+        <span class="nav-user">Logged in as {{ current_user_email or 'Unknown user' }}</span>
         <a href="/dashboard/today">Today</a>
         <a href="/admin/dashboard">Admin</a>
-		<a href="/profile">Preferences</a>
+                <a href="/profile">Preferences</a>
         <a href="/logout">Logout</a>
     </div>
 </div>
@@ -324,7 +336,7 @@
         </p>
     </header>
 
-    <form method="get" action="/dashboard/today" style="margin: 8px 0 18px 0;">
+    <form method="get" action="/dashboard/today" style="margin: 8px 0 6px 0; display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
         <label style="font-size: 13px; color: #7a748f; margin-right: 8px;">
             View date:
             <input
@@ -334,6 +346,9 @@
                 style="padding: 4px 6px; border-radius: 6px; border: 1px solid #ccc; font-size: 13px;"
             >
         </label>
+        <span style="font-size: 12px; color: #4b3b86; background: #f0eaff; padding: 6px 10px; border-radius: 8px;">
+            Timezone: {{ user_timezone or 'UTC' }}
+        </span>
         <button
             type="submit"
             style="
@@ -349,6 +364,7 @@
             Go
         </button>
     </form>
+    <p class="subtitle" style="margin-top: 0;">Times shown in {{ user_timezone or 'UTC' }}.</p>
 
     <!-- Top summary cards -->
     <div class="summary-grid">


### PR DESCRIPTION
## Summary
- display the logged-in user's email in the navigation on both today and session dashboards
- reuse the today dashboard navigation (including links) on the session summary page
- pass the current user's email into templates for rendering the user label

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a56c57004832e8c34070e4ca0ddaa)