### PR TITLE
Add hourly question counts to today activity sparkline

### DIFF
--- a/raterhub-tracker/app/main.py
+++ b/raterhub-tracker/app/main.py
@@ -36,6 +36,7 @@ from .models import (
     UserCreate,
     UserLogin,
     Token,
+    HourlyActivity,
 )
 from .auth import (
     get_password_hash,
@@ -831,6 +832,9 @@ def build_day_summary(
         .all()
     )
 
+    hourly_buckets: List[float] = [0.0 for _ in range(24)]
+    hourly_question_counts: List[int] = [0 for _ in range(24)]
+
     if not sessions:
         daily_pace = compute_pace(0.0, 0.0)
         return TodaySummary(
@@ -846,6 +850,10 @@ def build_day_summary(
             daily_pace_emoji=daily_pace["pace_emoji"],
             daily_pace_score=daily_pace["score"],
             daily_pace_ratio=daily_pace["ratio"],
+            hourly_activity=[
+                HourlyActivity(hour=hour, active_seconds=0.0, total_questions=0)
+                for hour in range(24)
+            ],
             sessions=[],
         )
 
@@ -898,6 +906,14 @@ def build_day_summary(
         total_active_all += total_active
         total_target_minutes_weighted += target_minutes * count
 
+        for q in qs:
+            started_local = to_user_local(q.started_at, user)
+            if started_local is None:
+                continue
+            bucket_hour = started_local.hour
+            hourly_buckets[bucket_hour] += q.active_seconds or 0.0
+            hourly_question_counts[bucket_hour] += 1
+
         items.append(
             TodaySessionItem(
                 session_id=s.public_id,
@@ -924,6 +940,15 @@ def build_day_summary(
     )
     daily_pace = compute_pace(avg_active_day, avg_target_minutes)
 
+    hourly_activity = [
+        HourlyActivity(
+            hour=hour,
+            active_seconds=seconds,
+            total_questions=hourly_question_counts[hour],
+        )
+        for hour, seconds in enumerate(hourly_buckets)
+    ]
+
     return TodaySummary(
         date=local_start,  # stored as local midnight in user's TZ
         user_external_id=user.email,
@@ -937,6 +962,7 @@ def build_day_summary(
         daily_pace_emoji=daily_pace["pace_emoji"],
         daily_pace_score=daily_pace["score"],
         daily_pace_ratio=daily_pace["ratio"],
+        hourly_activity=hourly_activity,
         sessions=items,
     )
 

--- a/raterhub-tracker/app/models.py
+++ b/raterhub-tracker/app/models.py
@@ -85,6 +85,12 @@ class TodaySessionItem(BaseModel):
     score: int
 
 
+class HourlyActivity(BaseModel):
+    hour: int
+    active_seconds: float
+    total_questions: int
+
+
 class TodaySummary(BaseModel):
     date: datetime
     user_external_id: str
@@ -101,6 +107,7 @@ class TodaySummary(BaseModel):
     daily_pace_score: int
     daily_pace_ratio: float
 
+    hourly_activity: list[HourlyActivity]
     sessions: list[TodaySessionItem]
 
 class Token(BaseModel):

--- a/raterhub-tracker/app/templates/today.html
+++ b/raterhub-tracker/app/templates/today.html
@@ -119,6 +119,47 @@
             max-width: 100%;
         }
 
+        .hourly-activity-card {
+            background: var(--card-bg);
+            border-radius: 14px;
+            padding: 14px 16px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.06);
+            border: 1px solid var(--border-subtle);
+            margin-bottom: 22px;
+        }
+
+        .hourly-bars {
+            display: flex;
+            align-items: flex-end;
+            gap: 6px;
+            height: 90px;
+            margin-top: 12px;
+        }
+
+        .hourly-bar {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .hourly-bar-fill {
+            width: 100%;
+            background: linear-gradient(180deg, #c2b5ff, #6c5ce7);
+            border-radius: 6px 6px 2px 2px;
+        }
+
+        .hourly-label {
+            font-size: 10px;
+            color: var(--text-muted);
+        }
+
+        .hourly-value {
+            font-size: 10px;
+            color: var(--text-muted);
+        }
+
         .section-title {
             font-size: 16px;
             color: var(--accent-dark);
@@ -362,6 +403,29 @@
                 Based on average time vs target
             </div>
         </div>
+    </div>
+
+    <div class="hourly-activity-card">
+        <h2 class="section-title" style="margin-top: 0;">Hourly activity</h2>
+        <p class="section-subtitle" style="margin-bottom: 8px;">
+            Active seconds grouped by local hour (timezone: {{ user_timezone or 'UTC' }}).
+        </p>
+        {% set max_active = (summary.hourly_activity | map(attribute='active_seconds') | max) if summary.hourly_activity else 0 %}
+        {% if not max_active %}
+            <div class="empty-state" style="margin-top: 8px;">No activity recorded this day.</div>
+        {% else %}
+            <div class="hourly-bars">
+                {% for bucket in summary.hourly_activity %}
+                    {% set pct = (bucket.active_seconds / max_active * 100) if max_active else 0 %}
+                    {% set question_label = 'question' if bucket.total_questions == 1 else 'questions' %}
+                    <div class="hourly-bar" title="{{ "%02d:00" % bucket.hour }} — {{ bucket.total_questions }} {{ question_label }} answered"> 
+                        <div class="hourly-bar-fill" style="height: {{ pct }}%;"></div>
+                        <div class="hourly-label">{{ "%02d" % bucket.hour }}</div>
+                        <div class="hourly-value">{{ bucket.active_seconds | round(0) | int }}s</div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
     </div>
 
     <!-- Per-session details -->


### PR DESCRIPTION
## Summary
- include hourly question totals in the day summary API response
- expose question counts in the hourly activity visualization via hover tooltips

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a4c024728832ea014ee4d13822918)