### PR TITLE
Remove hourly buckets and simplify sparkline

### DIFF
--- a/raterhub-tracker/app/templates/today.html
+++ b/raterhub-tracker/app/templates/today.html
@@ -119,6 +119,48 @@
             max-width: 100%;
         }
 
+        .hourly-activity-card {
+            background: var(--card-bg);
+            border-radius: 14px;
+            padding: 14px 16px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.06);
+            border: 1px solid var(--border-subtle);
+            margin-bottom: 22px;
+        }
+
+        .hourly-bars {
+            display: grid;
+            grid-template-columns: repeat(24, 1fr);
+            gap: 6px;
+            align-items: end;
+            height: 90px;
+            margin-top: 12px;
+        }
+
+        .hourly-bar {
+            height: 100%;
+            position: relative;
+        }
+
+        .hourly-bar-fill {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            height: 55%;
+            background: linear-gradient(180deg, #c2b5ff, #6c5ce7);
+            border-radius: 6px 6px 2px 2px;
+        }
+
+        .hourly-label {
+            position: absolute;
+            bottom: -16px;
+            width: 100%;
+            text-align: center;
+            font-size: 10px;
+            color: var(--text-muted);
+        }
+
         .section-title {
             font-size: 16px;
             color: var(--accent-dark);
@@ -361,6 +403,21 @@
             <div class="summary-extra">
                 Based on average time vs target
             </div>
+        </div>
+    </div>
+
+    <div class="hourly-activity-card">
+        <h2 class="section-title" style="margin-top: 0;">Hourly sparkline</h2>
+        <p class="section-subtitle" style="margin-bottom: 8px;">
+            Hover to see the local hour (timezone: {{ user_timezone or 'UTC' }}).
+        </p>
+        <div class="hourly-bars" aria-label="Hourly sparkline">
+            {% for hour in range(0, 24) %}
+                <div class="hourly-bar" title="{{ "%02d:00" % hour }}">
+                    <div class="hourly-bar-fill"></div>
+                    <div class="hourly-label">{{ "%02d" % hour }}</div>
+                </div>
+            {% endfor %}
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- drop hourly activity aggregation and related API field from day summaries
- simplify the Today dashboard sparkline to a static hourly hover guide without per-hour data
- remove hourly aggregation test coverage that depended on the removed buckets

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a4c024728832ea014ee4d13822918)