### PR TITLE
Add hourly sparkline timestamps and tooltip

### DIFF
--- a/raterhub-tracker/app/main.py
+++ b/raterhub-tracker/app/main.py
@@ -836,10 +836,17 @@ def build_day_summary(
         .all()
     )
 
-    hourly_activity = [0 for _ in range(24)]
+    hourly_activity = [
+        HourlyActivity(
+            hour=h,
+            total_questions=0,
+            active_seconds=0.0,
+            bucket_start=local_start + timedelta(hours=h),
+        )
+        for h in range(24)
+    ]
 
     if not sessions:
-        hourly_buckets = [0.0 for _ in range(24)]
         daily_pace = compute_pace(0.0, 0.0)
         return TodaySummary(
             date=local_start,  # report date as local midnight
@@ -879,7 +886,9 @@ def build_day_summary(
                 continue
             if q_local_start < local_start or q_local_start >= local_end:
                 continue
-            hourly_activity[q_local_start.hour] += 1
+            bucket = hourly_activity[q_local_start.hour]
+            bucket.total_questions += 1
+            bucket.active_seconds += q.active_seconds or 0.0
 
         if not qs:
             items.append(

--- a/raterhub-tracker/app/models.py
+++ b/raterhub-tracker/app/models.py
@@ -87,7 +87,9 @@ class TodaySessionItem(BaseModel):
 
 class HourlyActivity(BaseModel):
     hour: int
-    active_seconds: float
+    total_questions: int = 0
+    active_seconds: float = 0.0
+    bucket_start: datetime | None = None
 
 
 class TodaySummary(BaseModel):
@@ -105,7 +107,7 @@ class TodaySummary(BaseModel):
     daily_pace_emoji: str
 
     # Optional for backward compatibility with older templates/clients expecting this field.
-    hourly_activity: list = Field(default_factory=list)
+    hourly_activity: list[HourlyActivity] = Field(default_factory=list)
 
     sessions: list[TodaySessionItem]
 

--- a/raterhub-tracker/app/templates/today.html
+++ b/raterhub-tracker/app/templates/today.html
@@ -165,6 +165,21 @@
             margin-top: 6px;
         }
 
+        .sparkline-tooltip {
+            position: absolute;
+            padding: 6px 8px;
+            background: var(--card-bg);
+            border: 1px solid var(--border-subtle);
+            border-radius: 8px;
+            box-shadow: 0 6px 18px rgba(0,0,0,0.12);
+            font-size: 12px;
+            color: var(--text-main);
+            pointer-events: none;
+            transform: translate(-50%, -110%);
+            white-space: nowrap;
+            z-index: 10;
+        }
+
         .section-title {
             font-size: 16px;
             color: var(--accent-dark);
@@ -412,7 +427,8 @@
     </div>
 
     {% set hourly = summary.hourly_activity or [] %}
-    {% set max_bucket = (hourly | max) if hourly else 0 %}
+    {% set hourly_totals = hourly | map(attribute='total_questions') | list %}
+    {% set max_bucket = (hourly_totals | max) if hourly_totals else 0 %}
     <div class="wide-card">
         <div class="summary-label">Hourly Activity</div>
         <div class="summary-value" style="font-size: 18px; color: var(--text-muted); font-weight: 500;">
@@ -420,11 +436,18 @@
         </div>
         {% if hourly and max_bucket > 0 %}
             <div class="sparkline-grid large">
-                {% for count in hourly %}
-                    {% set scale = (count / max_bucket * 100) if max_bucket > 0 else 0 %}
-                    <div class="sparkline-col" style="height: {{ 10 + (scale * 0.9) }}%; opacity: {{ 0.3 + (0.7 * (scale / 100)) }};"></div>
+                {% for bucket in hourly %}
+                    {% set scale = (bucket.total_questions / max_bucket * 100) if max_bucket > 0 else 0 %}
+                    <div
+                        class="sparkline-col"
+                        data-hour="{{ bucket.hour }}"
+                        data-bucket-start="{{ bucket.bucket_start.isoformat() if bucket.bucket_start else '' }}"
+                        data-total-questions="{{ bucket.total_questions }}"
+                        style="height: {{ 10 + (scale * 0.9) }}%; opacity: {{ 0.3 + (0.7 * (scale / 100)) }};"
+                    ></div>
                 {% endfor %}
             </div>
+            <div id="sparkline-tooltip" class="sparkline-tooltip" style="display: none;"></div>
             <div class="sparkline-caption">Peak hour shows as the tallest column</div>
         {% else %}
             <div class="sparkline-caption" style="margin-top: 8px;">No hourly activity yet today</div>
@@ -514,5 +537,45 @@
         </div>
     {% endif %}
 </div>
+
+<script>
+    (function() {
+        const tooltip = document.getElementById('sparkline-tooltip');
+        const columns = document.querySelectorAll('.sparkline-col');
+
+        if (!tooltip || !columns.length) return;
+
+        function formatLocalTime(isoString) {
+            if (!isoString) return '';
+            const date = new Date(isoString);
+            if (Number.isNaN(date.getTime())) return '';
+            return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+        }
+
+        function updateTooltipPosition(event) {
+            tooltip.style.left = `${event.pageX}px`;
+            tooltip.style.top = `${event.pageY}px`;
+        }
+
+        columns.forEach((col) => {
+            col.addEventListener('mouseenter', (event) => {
+                const startIso = col.dataset.bucketStart || '';
+                const count = Number(col.dataset.totalQuestions || '0');
+                const timeLabel = formatLocalTime(startIso);
+
+                const countLabel = `${count} question${count === 1 ? '' : 's'}`;
+                tooltip.textContent = timeLabel ? `${timeLabel} · ${countLabel}` : countLabel;
+                tooltip.style.display = 'block';
+                updateTooltipPosition(event);
+            });
+
+            col.addEventListener('mousemove', updateTooltipPosition);
+
+            col.addEventListener('mouseleave', () => {
+                tooltip.style.display = 'none';
+            });
+        });
+    })();
+</script>
 </body>
 </html>

--- a/raterhub-tracker/tests/test_today_summary.py
+++ b/raterhub-tracker/tests/test_today_summary.py
@@ -26,6 +26,7 @@ def test_build_day_summary_populates_hourly_buckets():
 
     assert ten_am_bucket.total_questions == 1
     assert ten_am_bucket.active_seconds == 45.0
+    assert ten_am_bucket.bucket_start.hour == 10
     assert summary.total_questions == 1
     assert summary.total_active_seconds == 45.0
     assert summary.total_sessions == 1


### PR DESCRIPTION
## Summary
- capture hourly activity buckets with timestamps, totals, and active seconds
- expose hourly buckets in the today dashboard sparkline with hover tooltips showing local times
- add test coverage for hourly bucket timestamps

## Testing
- PYTHONPATH=. pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ade633b88832eb40cc3f845e36581)