### PR TITLE
Add bottom axis to hourly sparkline

### DIFF
--- a/raterhub-tracker/app/templates/today.html
+++ b/raterhub-tracker/app/templates/today.html
@@ -152,11 +152,40 @@
             margin-top: 14px;
         }
 
+        .sparkline-wrapper {
+            position: relative;
+            margin-top: 4px;
+        }
+
         .sparkline-col {
             flex: 1;
             border-radius: 6px;
             background: linear-gradient(180deg, rgba(166, 107, 255, 0.25), rgba(255, 110, 199, 0.8));
             min-height: 4px;
+        }
+
+        .sparkline-axis {
+            position: relative;
+            height: 30px;
+            margin-top: 10px;
+            border-top: 1px solid var(--border-subtle);
+        }
+
+        .sparkline-tick {
+            position: absolute;
+            top: -1px;
+            transform: translateX(-50%);
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 11px;
+            min-width: 26px;
+        }
+
+        .sparkline-tick-line {
+            width: 1px;
+            height: 6px;
+            background: var(--border-subtle);
+            margin: 0 auto 4px;
         }
 
         .sparkline-caption {
@@ -435,17 +464,20 @@
             Questions started each hour (local time)
         </div>
         {% if hourly and max_bucket > 0 %}
-            <div class="sparkline-grid large">
-                {% for bucket in hourly %}
-                    {% set scale = (bucket.total_questions / max_bucket * 100) if max_bucket > 0 else 0 %}
-                    <div
-                        class="sparkline-col"
-                        data-hour="{{ bucket.hour }}"
-                        data-bucket-start="{{ bucket.bucket_start.isoformat() if bucket.bucket_start else '' }}"
-                        data-total-questions="{{ bucket.total_questions }}"
-                        style="height: {{ 10 + (scale * 0.9) }}%; opacity: {{ 0.3 + (0.7 * (scale / 100)) }};"
-                    ></div>
-                {% endfor %}
+            <div class="sparkline-wrapper">
+                <div class="sparkline-grid large" id="sparkline-grid">
+                    {% for bucket in hourly %}
+                        {% set scale = (bucket.total_questions / max_bucket * 100) if max_bucket > 0 else 0 %}
+                        <div
+                            class="sparkline-col"
+                            data-hour="{{ bucket.hour }}"
+                            data-bucket-start="{{ bucket.bucket_start.isoformat() if bucket.bucket_start else '' }}"
+                            data-total-questions="{{ bucket.total_questions }}"
+                            style="height: {{ 10 + (scale * 0.9) }}%; opacity: {{ 0.3 + (0.7 * (scale / 100)) }};"
+                        ></div>
+                    {% endfor %}
+                </div>
+                <div class="sparkline-axis" id="sparkline-axis"></div>
             </div>
             <div id="sparkline-tooltip" class="sparkline-tooltip" style="display: none;"></div>
             <div class="sparkline-caption">Peak hour shows as the tallest column</div>
@@ -541,9 +573,11 @@
 <script>
     (function() {
         const tooltip = document.getElementById('sparkline-tooltip');
+        const axis = document.getElementById('sparkline-axis');
+        const grid = document.getElementById('sparkline-grid');
         const columns = document.querySelectorAll('.sparkline-col');
 
-        if (!tooltip || !columns.length) return;
+        if (!tooltip || !axis || !grid || !columns.length) return;
 
         function formatLocalTime(isoString) {
             if (!isoString) return '';
@@ -556,6 +590,70 @@
             tooltip.style.left = `${event.pageX}px`;
             tooltip.style.top = `${event.pageY}px`;
         }
+
+        function formatTickLabel(date) {
+            const hours = date.getHours();
+            const suffix = hours < 12 ? 'a' : 'p';
+            const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+            return `${hour12}${suffix}`;
+        }
+
+        function buildAxisTicks() {
+            const starts = Array.from(columns)
+                .map((col) => col.dataset.bucketStart)
+                .filter(Boolean)
+                .map((value) => new Date(value))
+                .filter((d) => !Number.isNaN(d.getTime()));
+
+            if (!starts.length) return;
+
+            const earliest = new Date(Math.min(...starts.map((d) => d.getTime())));
+            const dayStart = new Date(earliest);
+            dayStart.setHours(0, 0, 0, 0);
+
+            const dayEnd = new Date(dayStart);
+            dayEnd.setDate(dayEnd.getDate() + 1);
+            const msPerDay = dayEnd.getTime() - dayStart.getTime();
+
+            const gridWidth = grid.getBoundingClientRect().width || 0;
+            const desiredGap = 54;
+            const maxTicks = Math.max(2, Math.floor(gridWidth / desiredGap));
+            const candidates = [2, 3, 4, 6];
+            let chosenInterval = candidates[candidates.length - 1];
+
+            for (const candidate of candidates) {
+                const count = Math.floor(24 / candidate) + 1;
+                if (count <= maxTicks) {
+                    chosenInterval = candidate;
+                    break;
+                }
+            }
+
+            axis.innerHTML = '';
+
+            for (let hour = 0; hour <= 24; hour += chosenInterval) {
+                const tickTime = new Date(dayStart);
+                tickTime.setHours(hour, 0, 0, 0);
+                const percent = ((tickTime.getTime() - dayStart.getTime()) / msPerDay) * 100;
+
+                const tick = document.createElement('div');
+                tick.className = 'sparkline-tick';
+                tick.style.left = `${percent}%`;
+
+                const line = document.createElement('div');
+                line.className = 'sparkline-tick-line';
+
+                const label = document.createElement('div');
+                label.className = 'sparkline-tick-label';
+                label.textContent = formatTickLabel(tickTime);
+
+                tick.appendChild(line);
+                tick.appendChild(label);
+                axis.appendChild(tick);
+            }
+        }
+
+        buildAxisTicks();
 
         columns.forEach((col) => {
             col.addEventListener('mouseenter', (event) => {


### PR DESCRIPTION
## Summary
- add a styled bottom axis beneath the hourly sparkline that matches the summary card styling
- generate evenly spaced tick marks using the sparkline time scale with concise hour labels and adaptive density
- keep tooltip behavior while aligning tick positions to the sparkline columns

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae0e923c8832e9d5ffe5effa70b17)