### PR TITLE
Add Chrome extension implementation for RaterHub tracker

### DIFF
--- a/raterhub-tracker/extension/background.js
+++ b/raterhub-tracker/extension/background.js
@@ -1,0 +1,314 @@
+const API_BASE = "https://api.raterhub.steigenga.com";
+const LOGIN_EMAIL = "melissa517.freelancer@gmail.com";
+const LOGIN_PASSWORD = "super-secret";
+const AUTH_KEY = "raterhubAuth_v1";
+const STATUS_KEY = "raterhubLastStatus_v1";
+const throttleMap = {};
+
+let authState = {
+  accessToken: null,
+  csrfToken: null,
+};
+
+async function loadAuthFromStorage() {
+  try {
+    const stored = await chrome.storage.local.get([AUTH_KEY]);
+    if (stored && stored[AUTH_KEY]) {
+      authState = { ...authState, ...stored[AUTH_KEY] };
+    }
+  } catch (err) {
+    console.warn("[RaterHubTracker] Failed to load auth from storage", err);
+  }
+}
+
+async function persistAuthState() {
+  try {
+    await chrome.storage.local.set({ [AUTH_KEY]: authState });
+  } catch (err) {
+    console.warn("[RaterHubTracker] Failed to persist auth", err);
+  }
+}
+
+function setLastStatus(message) {
+  chrome.storage.local.set({ [STATUS_KEY]: message }).catch(() => {});
+}
+
+function throttle(key, windowMs = 750) {
+  const now = Date.now();
+  const last = throttleMap[key] || 0;
+  if (now - last < windowMs) {
+    return { throttled: true, retryIn: windowMs - (now - last) };
+  }
+  throttleMap[key] = now;
+  return { throttled: false };
+}
+
+async function fetchCsrfToken() {
+  const { throttled } = throttle("csrf", 500);
+  if (throttled) {
+    return { ok: false, error: "THROTTLED" };
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/auth/csrf`, {
+      method: "GET",
+      credentials: "include",
+    });
+
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: "CSRF_FAILED" };
+    }
+
+    const data = await res.json();
+    if (data && typeof data.csrf_token === "string") {
+      authState.csrfToken = data.csrf_token;
+      await persistAuthState();
+      return { ok: true, csrf: authState.csrfToken };
+    }
+  } catch (err) {
+    console.error("[RaterHubTracker] CSRF fetch error", err);
+    return { ok: false, error: "NETWORK" };
+  }
+
+  return { ok: false, error: "INVALID_RESPONSE" };
+}
+
+async function login() {
+  const { throttled } = throttle("login", 1000);
+  if (throttled) {
+    return { ok: false, error: "THROTTLED" };
+  }
+
+  if (!authState.csrfToken) {
+    const csrfRes = await fetchCsrfToken();
+    if (!csrfRes.ok) {
+      return csrfRes;
+    }
+  }
+
+  try {
+    let res = await fetch(`${API_BASE}/auth/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": authState.csrfToken || "",
+      },
+      credentials: "include",
+      body: JSON.stringify({
+        email: LOGIN_EMAIL,
+        password: LOGIN_PASSWORD,
+      }),
+    });
+
+    if (res.status === 400) {
+      // Likely bad CSRF token; refresh once.
+      authState.csrfToken = null;
+      await persistAuthState();
+      const refreshed = await fetchCsrfToken();
+      if (!refreshed.ok) {
+        return refreshed;
+      }
+
+      res = await fetch(`${API_BASE}/auth/login`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": authState.csrfToken || "",
+        },
+        credentials: "include",
+        body: JSON.stringify({
+          email: LOGIN_EMAIL,
+          password: LOGIN_PASSWORD,
+        }),
+      });
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      console.warn("[RaterHubTracker] Login failed", res.status, text);
+      setLastStatus(`Login failed (${res.status})`);
+      return { ok: false, status: res.status, error: "LOGIN_FAILED" };
+    }
+
+    const data = await res.json();
+    authState.accessToken = data.access_token;
+    await persistAuthState();
+    setLastStatus("Logged in");
+    return { ok: true, token: authState.accessToken };
+  } catch (err) {
+    console.error("[RaterHubTracker] Login error", err);
+    setLastStatus("Login error");
+    return { ok: false, error: "NETWORK" };
+  }
+}
+
+async function ensureAccessToken() {
+  if (authState.accessToken) {
+    return { ok: true, token: authState.accessToken };
+  }
+  return login();
+}
+
+async function fetchSessionSummary(sessionId) {
+  const gate = await ensureAccessToken();
+  if (!gate.ok) return gate;
+
+  const { throttled } = throttle(`summary-${sessionId}`, 500);
+  if (throttled) {
+    return { ok: false, error: "THROTTLED" };
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/sessions/${sessionId}/summary`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${authState.accessToken}`,
+      },
+    });
+
+    if (res.status === 401) {
+      authState.accessToken = null;
+      await persistAuthState();
+      return { ok: false, status: 401, error: "UNAUTHORIZED" };
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      console.warn("[RaterHubTracker] Summary failed", res.status, text);
+      return { ok: false, status: res.status, error: "SUMMARY_FAILED" };
+    }
+
+    const data = await res.json();
+    setLastStatus("Summary refreshed");
+    return { ok: true, summary: data };
+  } catch (err) {
+    console.error("[RaterHubTracker] Summary error", err);
+    return { ok: false, error: "NETWORK" };
+  }
+}
+
+async function findActiveSession() {
+  const gate = await ensureAccessToken();
+  if (!gate.ok) return gate;
+
+  const { throttled } = throttle("recent-sessions", 750);
+  if (throttled) {
+    return { ok: false, error: "THROTTLED" };
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/sessions/recent?limit=5`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${authState.accessToken}`,
+      },
+    });
+
+    if (res.status === 401) {
+      authState.accessToken = null;
+      await persistAuthState();
+      return { ok: false, status: 401, error: "UNAUTHORIZED" };
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      console.warn("[RaterHubTracker] Recent sessions failed", res.status, text);
+      return { ok: false, status: res.status, error: "RECENT_FAILED" };
+    }
+
+    const sessions = await res.json();
+    const active = Array.isArray(sessions) ? sessions.find((s) => s.is_active) : null;
+    return { ok: true, activeSession: active || null };
+  } catch (err) {
+    console.error("[RaterHubTracker] Recent sessions error", err);
+    return { ok: false, error: "NETWORK" };
+  }
+}
+
+async function sendEvent(eventType) {
+  const gate = await ensureAccessToken();
+  if (!gate.ok) return gate;
+
+  const { throttled } = throttle(`event-${eventType}`, 400);
+  if (throttled) {
+    return { ok: false, error: "THROTTLED" };
+  }
+
+  const payload = {
+    type: eventType,
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    const res = await fetch(`${API_BASE}/events`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authState.accessToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (res.status === 401) {
+      authState.accessToken = null;
+      await persistAuthState();
+      return { ok: false, status: 401, error: "UNAUTHORIZED" };
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      console.warn("[RaterHubTracker] Event failed", res.status, text);
+      setLastStatus(`Event ${eventType} failed (${res.status})`);
+      return { ok: false, status: res.status, error: "EVENT_FAILED" };
+    }
+
+    const data = await res.json();
+    setLastStatus(`Event ${eventType} recorded`);
+    return { ok: true, data };
+  } catch (err) {
+    console.error("[RaterHubTracker] Event error", err);
+    setLastStatus(`Event ${eventType} network error`);
+    return { ok: false, error: "NETWORK" };
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  (async () => {
+    switch (message?.type) {
+      case "LOGIN": {
+        const res = await login();
+        sendResponse(res);
+        return;
+      }
+      case "SEND_EVENT": {
+        const res = await sendEvent(message.eventType);
+        sendResponse(res);
+        return;
+      }
+      case "SESSION_SUMMARY": {
+        const res = await fetchSessionSummary(message.sessionId);
+        sendResponse(res);
+        return;
+      }
+      case "FIND_ACTIVE_SESSION": {
+        const res = await findActiveSession();
+        sendResponse(res);
+        return;
+      }
+      case "GET_STATUS": {
+        sendResponse({
+          ok: true,
+          authenticated: Boolean(authState.accessToken),
+          lastStatus: message.includeLastStatus ? (await chrome.storage.local.get([STATUS_KEY]))[STATUS_KEY] : undefined,
+        });
+        return;
+      }
+      default:
+        sendResponse({ ok: false, error: "UNKNOWN_MESSAGE" });
+        return;
+    }
+  })();
+  return true;
+});
+
+loadAuthFromStorage();

--- a/raterhub-tracker/extension/content/widget.js
+++ b/raterhub-tracker/extension/content/widget.js
@@ -1,0 +1,604 @@
+(() => {
+  const POS_KEY = "raterhubTrackerPos_v2";
+  const STATE_KEY = "raterhubTrackerState_v2";
+
+  // --- UI + session state ---
+  let questionIndex = 0;
+  let currentSessionId = null;
+  let questionStartTime = null;
+  let accumulatedActiveMs = 0;
+  let timerIntervalId = null;
+  let isPaused = false;
+  let isCollapsed = false;
+
+  // --- Widget elements ---
+  let widget,
+    statusEl,
+    userEl,
+    questionEl,
+    timerEl,
+    lastEventEl,
+    bodyContainer,
+    toggleBtn,
+    sessionStatsEl;
+
+  // --- Drag state ---
+  let isDragging = false;
+  let dragStartMouseX = 0;
+  let dragStartMouseY = 0;
+  let dragStartLeft = 0;
+  let dragStartTop = 0;
+
+  function storageGet(key) {
+    return chrome.storage.local.get([key]).then((res) => res[key]);
+  }
+
+  function storageSet(key, value) {
+    return chrome.storage.local.set({ [key]: value });
+  }
+
+  // -----------------------------------------
+  // Persistence helpers
+  // -----------------------------------------
+
+  async function saveWidgetPosition() {
+    if (!widget) return;
+    try {
+      const rect = widget.getBoundingClientRect();
+      await storageSet(POS_KEY, { left: rect.left, top: rect.top });
+    } catch (e) {
+      console.warn("[RaterHubTracker] Failed to save widget position:", e);
+    }
+  }
+
+  async function loadWidgetPosition() {
+    if (!widget) return;
+    try {
+      const pos = await storageGet(POS_KEY);
+      if (pos && typeof pos.left === "number" && typeof pos.top === "number") {
+        widget.style.left = `${pos.left}px`;
+        widget.style.top = `${pos.top}px`;
+        widget.style.right = "auto";
+        widget.style.bottom = "auto";
+      }
+    } catch (e) {
+      console.warn("[RaterHubTracker] Failed to load widget position:", e);
+    }
+  }
+
+  async function saveState() {
+    try {
+      const state = {
+        questionIndex,
+        currentSessionId,
+        isCollapsed,
+      };
+      await storageSet(STATE_KEY, state);
+    } catch (e) {
+      console.warn("[RaterHubTracker] Failed to save state:", e);
+    }
+  }
+
+  async function loadState() {
+    try {
+      const state = await storageGet(STATE_KEY);
+      if (!state) return;
+      if (typeof state.questionIndex === "number") {
+        questionIndex = state.questionIndex;
+      }
+      if (typeof state.currentSessionId === "string") {
+        currentSessionId = state.currentSessionId;
+      }
+      if (typeof state.isCollapsed === "boolean") {
+        isCollapsed = state.isCollapsed;
+      }
+    } catch (e) {
+      console.warn("[RaterHubTracker] Failed to load state:", e);
+    }
+  }
+
+  // -----------------------------------------
+  // Widget creation & helpers
+  // -----------------------------------------
+
+  function applyCollapsedState() {
+    if (!bodyContainer || !toggleBtn) return;
+    if (isCollapsed) {
+      bodyContainer.style.display = "none";
+      toggleBtn.textContent = "▴";
+    } else {
+      bodyContainer.style.display = "block";
+      toggleBtn.textContent = "▾";
+    }
+  }
+
+  function createWidget() {
+    widget = document.createElement("div");
+    widget.id = "raterhub-tracker-widget";
+    widget.style.position = "fixed";
+    widget.style.bottom = "16px";
+    widget.style.right = "16px";
+    widget.style.zIndex = "999999";
+    widget.style.background = "#ffffff";
+    widget.style.borderRadius = "10px";
+    widget.style.boxShadow = "0 6px 18px rgba(0, 0, 0, 0.15)";
+    widget.style.padding = "8px 10px";
+    widget.style.fontFamily = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+    widget.style.fontSize = "12px";
+    widget.style.color = "#1f2933";
+    widget.style.minWidth = "240px";
+    widget.style.border = "2px solid #8b5cf6";
+    widget.style.backgroundImage = "linear-gradient(to bottom, #f9f5ff, #ffffff)";
+    widget.style.cursor = "default";
+
+    const header = document.createElement("div");
+    header.style.display = "flex";
+    header.style.alignItems = "center";
+    header.style.justifyContent = "space-between";
+    header.style.marginBottom = "4px";
+    header.style.cursor = "move";
+    header.style.userSelect = "none";
+    header.style.touchAction = "none";
+
+    const title = document.createElement("div");
+    title.textContent = "RaterHub Tracker";
+    title.style.fontWeight = "700";
+    title.style.fontSize = "13px";
+    title.style.color = "#6d28d9";
+
+    toggleBtn = document.createElement("button");
+    toggleBtn.textContent = "▾";
+    toggleBtn.style.border = "none";
+    toggleBtn.style.background = "transparent";
+    toggleBtn.style.color = "#4b5563";
+    toggleBtn.style.cursor = "pointer";
+    toggleBtn.style.fontSize = "14px";
+    toggleBtn.style.padding = "0 0 0 8px";
+    toggleBtn.style.lineHeight = "1";
+
+    header.appendChild(title);
+    header.appendChild(toggleBtn);
+
+    bodyContainer = document.createElement("div");
+
+    statusEl = document.createElement("div");
+    statusEl.textContent = "Loaded – logging in…";
+    statusEl.style.fontSize = "11px";
+    statusEl.style.marginBottom = "6px";
+    statusEl.style.color = "#4b5563";
+
+    userEl = document.createElement("div");
+    userEl.textContent = "User: (not logged in)";
+    userEl.style.marginBottom = "2px";
+
+    questionEl = document.createElement("div");
+    questionEl.textContent = "Question: –";
+    questionEl.style.marginBottom = "2px";
+
+    timerEl = document.createElement("div");
+    timerEl.textContent = "Timer: 00:00";
+    timerEl.style.marginBottom = "6px";
+    timerEl.style.fontFeatureSettings = '"tnum" 1';
+    timerEl.style.fontVariantNumeric = "tabular-nums";
+    timerEl.style.color = "#4c1d95";
+
+    sessionStatsEl = document.createElement("div");
+    sessionStatsEl.textContent = "Session: –";
+    sessionStatsEl.style.fontSize = "11px";
+    sessionStatsEl.style.marginBottom = "6px";
+    sessionStatsEl.style.color = "#4b5563";
+
+    lastEventEl = document.createElement("div");
+    lastEventEl.textContent = "Last event: –";
+    lastEventEl.style.fontSize = "11px";
+    lastEventEl.style.marginBottom = "6px";
+    lastEventEl.style.color = "#6b7280";
+
+    const hotkeys = document.createElement("div");
+    hotkeys.style.fontSize = "10px";
+    hotkeys.style.color = "#6b7280";
+    hotkeys.innerHTML = `
+            <strong>Keys:</strong>
+            Ctrl+Q = Next,
+            Ctrl+Shift+P = Pause,
+            Ctrl+Shift+X = Exit,
+            Ctrl+Shift+Q = Undo
+        `;
+
+    bodyContainer.appendChild(statusEl);
+    bodyContainer.appendChild(userEl);
+    bodyContainer.appendChild(questionEl);
+    bodyContainer.appendChild(timerEl);
+    bodyContainer.appendChild(sessionStatsEl);
+    bodyContainer.appendChild(lastEventEl);
+    bodyContainer.appendChild(hotkeys);
+
+    widget.appendChild(header);
+    widget.appendChild(bodyContainer);
+    document.body.appendChild(widget);
+
+    loadWidgetPosition();
+
+    header.addEventListener("pointerdown", onHeaderPointerDown);
+    document.addEventListener("pointermove", onDocumentPointerMove);
+    document.addEventListener("pointerup", onDocumentPointerUp);
+    document.addEventListener("pointercancel", onDocumentPointerUp);
+
+    toggleBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      isCollapsed = !isCollapsed;
+      applyCollapsedState();
+      saveState();
+    });
+
+    applyCollapsedState();
+  }
+
+  function onHeaderPointerDown(e) {
+    if (e.target === toggleBtn) return;
+
+    widget.setPointerCapture(e.pointerId);
+    isDragging = true;
+    dragStartMouseX = e.clientX;
+    dragStartMouseY = e.clientY;
+
+    const rect = widget.getBoundingClientRect();
+    dragStartLeft = rect.left;
+    dragStartTop = rect.top;
+
+    widget.style.left = `${dragStartLeft}px`;
+    widget.style.top = `${dragStartTop}px`;
+    widget.style.right = "auto";
+    widget.style.bottom = "auto";
+
+    e.preventDefault();
+  }
+
+  function onDocumentPointerMove(e) {
+    if (!isDragging) return;
+    const dx = e.clientX - dragStartMouseX;
+    const dy = e.clientY - dragStartMouseY;
+    widget.style.left = `${dragStartLeft + dx}px`;
+    widget.style.top = `${dragStartTop + dy}px`;
+  }
+
+  function onDocumentPointerUp(e) {
+    if (!isDragging) return;
+    isDragging = false;
+    try {
+      widget.releasePointerCapture(e.pointerId);
+    } catch (_) {}
+    saveWidgetPosition();
+  }
+
+  function setStatus(msg, color) {
+    if (!statusEl) return;
+    statusEl.textContent = msg;
+    statusEl.style.color = color || "#4b5563";
+  }
+
+  function flashWidget(color) {
+    if (!widget) return;
+    const original = widget.style.borderColor;
+    widget.style.borderColor = color;
+    setTimeout(() => {
+      widget.style.borderColor = original;
+    }, 250);
+  }
+
+  function updateUserDisplay(isLoggedIn) {
+    if (!userEl) return;
+    userEl.textContent = isLoggedIn ? "User: logged in" : "User: (not logged in)";
+  }
+
+  function updateQuestionDisplay() {
+    if (!questionEl) return;
+    questionEl.textContent = `Question: ${questionIndex > 0 ? questionIndex : "–"}`;
+  }
+
+  function formatMs(ms) {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60)
+      .toString()
+      .padStart(2, "0");
+    const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+    return `${minutes}:${seconds}`;
+  }
+
+  function updateTimerDisplay() {
+    if (!timerEl) return;
+    let elapsedMs = accumulatedActiveMs;
+    if (!isPaused && questionStartTime) {
+      elapsedMs += Date.now() - questionStartTime;
+    }
+    timerEl.textContent = `Timer: ${formatMs(elapsedMs)}`;
+  }
+
+  function startTimerLoop() {
+    if (timerIntervalId) return;
+    timerIntervalId = setInterval(updateTimerDisplay, 500);
+  }
+
+  function stopTimerLoop() {
+    if (!timerIntervalId) return;
+    clearInterval(timerIntervalId);
+    timerIntervalId = null;
+  }
+
+  function startNewQuestionTimer() {
+    accumulatedActiveMs = 0;
+    questionStartTime = Date.now();
+    isPaused = false;
+    updateTimerDisplay();
+    startTimerLoop();
+  }
+
+  function togglePauseTimer() {
+    if (isPaused) {
+      questionStartTime = Date.now();
+      isPaused = false;
+      startTimerLoop();
+      return;
+    }
+
+    if (questionStartTime) {
+      accumulatedActiveMs += Date.now() - questionStartTime;
+    }
+    questionStartTime = null;
+    isPaused = true;
+    updateTimerDisplay();
+    stopTimerLoop();
+  }
+
+  function exitTimer() {
+    accumulatedActiveMs = 0;
+    questionStartTime = null;
+    isPaused = false;
+    updateTimerDisplay();
+    stopTimerLoop();
+  }
+
+  function resetTimerForUndo() {
+    accumulatedActiveMs = 0;
+    questionStartTime = Date.now();
+    isPaused = false;
+    updateQuestionDisplay();
+    updateTimerDisplay();
+    startTimerLoop();
+  }
+
+  function updateSessionStatsText(text) {
+    if (!sessionStatsEl) return;
+    sessionStatsEl.textContent = text;
+  }
+
+  function hardResetSessionUI(reasonText) {
+    currentSessionId = null;
+    questionIndex = 0;
+    accumulatedActiveMs = 0;
+    questionStartTime = null;
+    isPaused = false;
+    stopTimerLoop();
+    updateQuestionDisplay();
+    updateTimerDisplay();
+    updateSessionStatsText(reasonText || "Session: –");
+    saveState();
+  }
+
+  // -----------------------------------------
+  // Messaging helpers
+  // -----------------------------------------
+
+  function sendRuntimeMessage(payload) {
+    return chrome.runtime.sendMessage(payload).catch((err) => {
+      console.warn("[RaterHubTracker] Message failed", payload, err);
+      return { ok: false, error: "MESSAGE_FAILED" };
+    });
+  }
+
+  async function refreshSessionSummary() {
+    if (!currentSessionId) {
+      hardResetSessionUI("Session: –");
+      return;
+    }
+
+    const res = await sendRuntimeMessage({
+      type: "SESSION_SUMMARY",
+      sessionId: currentSessionId,
+    });
+
+    if (!res?.ok) {
+      if (res?.error === "UNAUTHORIZED") {
+        updateUserDisplay(false);
+      }
+      updateSessionStatsText("Session: summary error");
+      return;
+    }
+
+    const summary = res.summary || {};
+    if (summary.is_active === false) {
+      hardResetSessionUI("Session: ended");
+      return;
+    }
+
+    const totalQ = summary.total_questions ?? 0;
+    const avg = summary.avg_active_mmss || "00:00";
+    const emoji = summary.pace_emoji || "";
+    const label = summary.pace_label || "";
+
+    updateSessionStatsText(`Session: ${totalQ} q, AHT ${avg} ${emoji} ${label}`);
+  }
+
+  async function syncFromBackend() {
+    if (currentSessionId) {
+      await refreshSessionSummary();
+      return;
+    }
+
+    const res = await sendRuntimeMessage({ type: "FIND_ACTIVE_SESSION" });
+    if (!res?.ok || !res.activeSession) {
+      updateSessionStatsText("Session: –");
+      return;
+    }
+
+    const active = res.activeSession;
+    currentSessionId = active.session_id;
+    if (typeof active.current_question_index === "number") {
+      questionIndex = active.current_question_index;
+      updateQuestionDisplay();
+    }
+    await refreshSessionSummary();
+    saveState();
+  }
+
+  async function login() {
+    setStatus("Logging in…", "#4b5563");
+    const res = await sendRuntimeMessage({ type: "LOGIN" });
+
+    if (!res?.ok) {
+      setStatus("Login failed", "#b91c1c");
+      flashWidget("#ef4444");
+      updateUserDisplay(false);
+      return;
+    }
+
+    updateUserDisplay(true);
+    setStatus("Logged in ✔", "#15803d");
+    flashWidget("#22c55e");
+    await syncFromBackend();
+  }
+
+  async function sendEvent(eventType) {
+    const res = await sendRuntimeMessage({ type: "SEND_EVENT", eventType });
+
+    if (!res?.ok) {
+      if (res?.error === "THROTTLED") {
+        setStatus(`Event ${eventType} throttled`, "#b45309");
+      } else if (res?.error === "UNAUTHORIZED") {
+        setStatus("Re-authenticating…", "#b45309");
+        updateUserDisplay(false);
+        await login();
+      } else {
+        setStatus(`Event ${eventType} failed`, "#b91c1c");
+      }
+      lastEventEl.textContent = `Last event: ${eventType} (error)`;
+      flashWidget("#ef4444");
+      return;
+    }
+
+    const data = res.data || {};
+    setStatus(`Event ${eventType} recorded ✔`, "#15803d");
+    lastEventEl.textContent = `Last event: ${eventType} @ ${new Date().toLocaleTimeString()}`;
+    flashWidget("#22c55e");
+
+    if (data && typeof data.session_id === "string") {
+      currentSessionId = data.session_id;
+    }
+
+    const backendTotal = typeof data.total_questions === "number" ? data.total_questions : null;
+
+    if (eventType === "NEXT") {
+      if (backendTotal !== null) {
+        questionIndex = backendTotal;
+      } else {
+        questionIndex += 1;
+      }
+      saveState();
+      startNewQuestionTimer();
+    } else if (eventType === "PAUSE") {
+      togglePauseTimer();
+      saveState();
+    } else if (eventType === "EXIT") {
+      if (backendTotal !== null) {
+        questionIndex = backendTotal;
+      }
+      saveState();
+      exitTimer();
+    } else if (eventType === "UNDO") {
+      if (backendTotal !== null) {
+        questionIndex = backendTotal;
+      } else if (questionIndex > 0) {
+        questionIndex -= 1;
+      }
+      saveState();
+      resetTimerForUndo();
+    }
+
+    updateQuestionDisplay();
+    await refreshSessionSummary();
+    saveState();
+  }
+
+  // -----------------------------------------
+  // Keyboard handling
+  // -----------------------------------------
+
+  function handleKeydown(e) {
+    const tag = e.target && e.target.tagName ? e.target.tagName.toLowerCase() : "";
+    if (tag === "input" || tag === "textarea" || tag === "select" || e.isComposing) {
+      return;
+    }
+
+    if (e.ctrlKey && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "q") {
+      e.preventDefault();
+      sendEvent("NEXT");
+      return;
+    }
+
+    if (e.ctrlKey && e.shiftKey && !e.altKey && e.key.toLowerCase() === "p") {
+      e.preventDefault();
+      sendEvent("PAUSE");
+      return;
+    }
+
+    if (e.ctrlKey && e.shiftKey && !e.altKey && e.key.toLowerCase() === "x") {
+      e.preventDefault();
+      sendEvent("EXIT");
+      return;
+    }
+
+    if (e.ctrlKey && e.shiftKey && !e.altKey && e.key.toLowerCase() === "q") {
+      e.preventDefault();
+      sendEvent("UNDO");
+    }
+  }
+
+  // -----------------------------------------
+  // Init
+  // -----------------------------------------
+
+  async function init() {
+    createWidget();
+    await loadState();
+    updateQuestionDisplay();
+    updateTimerDisplay();
+    applyCollapsedState();
+    updateUserDisplay(false);
+    setStatus("Loaded – logging in…", "#4b5563");
+    updateSessionStatsText("Session: –");
+
+    window.addEventListener("keydown", handleKeydown, true);
+    chrome.runtime.onMessage.addListener((message) => {
+      if (message?.type === "SESSION_SUMMARY_RELAY" && message.summary) {
+        const summary = message.summary;
+        if (summary.is_active === false) {
+          hardResetSessionUI("Session: ended");
+          return;
+        }
+        const totalQ = summary.total_questions ?? 0;
+        const avg = summary.avg_active_mmss || "00:00";
+        const emoji = summary.pace_emoji || "";
+        const label = summary.pace_label || "";
+        updateSessionStatsText(`Session: ${totalQ} q, AHT ${avg} ${emoji} ${label}`);
+      }
+    });
+
+    await login();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/raterhub-tracker/extension/manifest.json
+++ b/raterhub-tracker/extension/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 3,
+  "name": "RaterHub Tracker",
+  "description": "Floating tracker widget for RaterHub sessions backed by the RaterHub Tracker API.",
+  "version": "0.9.0",
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://*.raterhub.com/*",
+    "https://api.raterhub.steigenga.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*.raterhub.com/*"],
+      "js": ["content/widget.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "RaterHub Tracker",
+    "default_popup": "popup.html"
+  }
+}

--- a/raterhub-tracker/extension/popup.html
+++ b/raterhub-tracker/extension/popup.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>RaterHub Tracker</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 12px;
+        color: #1f2933;
+        width: 320px;
+      }
+      h1 {
+        margin: 0 0 8px 0;
+        font-size: 18px;
+        color: #6d28d9;
+      }
+      .card {
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        padding: 10px;
+        margin-bottom: 12px;
+        background: #f9f5ff;
+      }
+      ul {
+        padding-left: 18px;
+        margin: 6px 0;
+      }
+      .muted {
+        color: #6b7280;
+        font-size: 12px;
+      }
+      .status {
+        margin-top: 6px;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>RaterHub Tracker</h1>
+    <div class="card">
+      <div class="status" id="auth-status">Checking login…</div>
+      <div id="last-status" class="muted">—</div>
+    </div>
+    <div class="card">
+      <strong>Shortcuts</strong>
+      <ul>
+        <li><code>Ctrl + Q</code> — Next question</li>
+        <li><code>Ctrl + Shift + P</code> — Pause/Resume</li>
+        <li><code>Ctrl + Shift + X</code> — Exit session</li>
+        <li><code>Ctrl + Shift + Q</code> — Undo last</li>
+      </ul>
+    </div>
+    <div class="card">
+      <strong>Session status</strong>
+      <div class="muted">Widget state persists per-tab; dragging & collapse are saved.</div>
+      <div id="session-info" class="status">Loading…</div>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/raterhub-tracker/extension/popup.js
+++ b/raterhub-tracker/extension/popup.js
@@ -1,0 +1,45 @@
+const STATE_KEY = "raterhubTrackerState_v2";
+const STATUS_KEY = "raterhubLastStatus_v1";
+
+async function loadPopupData() {
+  const authStatusEl = document.getElementById("auth-status");
+  const lastStatusEl = document.getElementById("last-status");
+  const sessionInfoEl = document.getElementById("session-info");
+
+  const statusResp = await chrome.runtime.sendMessage({
+    type: "GET_STATUS",
+    includeLastStatus: true,
+  });
+
+  if (statusResp?.authenticated) {
+    authStatusEl.textContent = "Logged in";
+    authStatusEl.style.color = "#15803d";
+  } else {
+    authStatusEl.textContent = "Not logged in";
+    authStatusEl.style.color = "#b91c1c";
+  }
+
+  if (statusResp?.lastStatus) {
+    lastStatusEl.textContent = statusResp.lastStatus;
+  } else {
+    lastStatusEl.textContent = "No recent activity";
+  }
+
+  const stored = await chrome.storage.local.get([STATE_KEY, STATUS_KEY]);
+  const state = stored[STATE_KEY];
+
+  if (!state) {
+    sessionInfoEl.textContent = "No active session in this browser.";
+    sessionInfoEl.style.color = "#6b7280";
+    return;
+  }
+
+  const questionText = typeof state.questionIndex === "number" && state.questionIndex > 0
+    ? `Question: ${state.questionIndex}`
+    : "Question: –";
+
+  const collapsed = state.isCollapsed ? "Widget collapsed" : "Widget expanded";
+  sessionInfoEl.textContent = `${questionText} • ${collapsed}`;
+}
+
+document.addEventListener("DOMContentLoaded", loadPopupData);


### PR DESCRIPTION
## Summary
- add a Manifest V3 Chrome extension with service worker, content script, and popup for the RaterHub tracker
- move the userscript widget logic into a content script that stores position/state and delegates API calls via background messaging
- implement authenticated, throttled background fetches for events and session summaries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b197aa31c832eaf07b4e30992bc87)