### PR TITLE
Add migration script for user name columns

### DIFF
--- a/raterhub-tracker/app/db_models.py
+++ b/raterhub-tracker/app/db_models.py
@@ -23,6 +23,8 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     external_id = Column(String, unique=True, index=True, nullable=False)
     email = Column(String, unique=True, index=True, nullable=False)
+    first_name = Column(String, nullable=True, default="")
+    last_name = Column(String, nullable=True, default="")
 
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     last_login_at = Column(DateTime, nullable=True)

--- a/raterhub-tracker/app/models.py
+++ b/raterhub-tracker/app/models.py
@@ -124,6 +124,8 @@ class TokenData(BaseModel):
 class UserCreate(BaseModel):
     email: EmailStr
     password: str
+    first_name: Optional[str] = ""
+    last_name: Optional[str] = ""
 
 
 class UserLogin(BaseModel):

--- a/raterhub-tracker/app/templates/profile.html
+++ b/raterhub-tracker/app/templates/profile.html
@@ -1,97 +1,261 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Your Profile – RaterHub Tracker</title>
-    <style>
-        body {
-            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-            background: #f5f2ff;
-            margin: 0;
-            padding: 0;
-        }
-        .container {
-            max-width: 640px;
-            margin: 40px auto;
-            background: #ffffff;
-            border-radius: 12px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.06);
-            padding: 24px 28px;
-        }
-        h1 {
-            margin-top: 0;
-            color: #4a2e8a;
-        }
-        label {
-            display: block;
-            margin-top: 16px;
-            font-weight: 600;
-            color: #333;
-        }
-        input[type="text"], select {
-            width: 100%;
-            padding: 8px 10px;
-            margin-top: 6px;
-            border-radius: 8px;
-            border: 1px solid #ccc;
-            font-size: 14px;
-        }
-        button {
-            margin-top: 20px;
-            padding: 10px 18px;
-            border-radius: 999px;
-            border: none;
-            background: #7c3aed;
-            color: #fff;
-            font-weight: 600;
-            cursor: pointer;
-        }
-        button:hover {
-            background: #6d28d9;
-        }
-        .message {
-            margin-top: 12px;
-            color: #15803d;
-            font-size: 14px;
-        }
-        .nav {
-            margin-bottom: 16px;
-        }
-        .nav a {
-            color: #7c3aed;
-            text-decoration: none;
-            margin-right: 12px;
-            font-size: 14px;
-        }
-        .nav a:hover {
-            text-decoration: underline;
-        }
-    </style>
-</head>
-<body>
-<div class="container">
-    <div class="nav">
+{% extends "base.html" %}
+{% block title %}Your Profile – RaterHub Tracker{% endblock %}
+
+{% block content %}
+<style>
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 16px;
+    }
+
+    .page-header a {
+        color: var(--accent);
+        font-size: 13px;
+        text-decoration: none;
+        font-weight: 600;
+    }
+
+    .page-header a:hover {
+        color: var(--accent-dark);
+        text-decoration: underline;
+    }
+
+    .card-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 16px;
+    }
+
+    .form-field {
+        margin-bottom: 12px;
+    }
+
+    .form-field label {
+        display: block;
+        font-size: 13px;
+        margin-bottom: 6px;
+        font-weight: 600;
+        color: var(--accent-dark);
+    }
+
+    .input, select {
+        width: 100%;
+        padding: 9px 10px;
+        border-radius: 10px;
+        border: 1px solid var(--border-subtle);
+        font-size: 14px;
+        box-sizing: border-box;
+        background: #fff;
+    }
+
+    select {
+        background: #fff;
+    }
+
+    .input[readonly] {
+        background: #f7f3ff;
+        color: var(--text-muted);
+    }
+
+    .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
+        margin-top: 6px;
+    }
+
+    .btn {
+        border: none;
+        border-radius: 999px;
+        padding: 10px 16px;
+        font-weight: 700;
+        cursor: pointer;
+        font-size: 14px;
+    }
+
+    .btn-primary {
+        background: var(--accent);
+        color: #fff;
+    }
+
+    .btn-primary:hover {
+        background: var(--accent-dark);
+    }
+
+    .alert {
+        border-radius: 12px;
+        padding: 10px 12px;
+        font-size: 13px;
+        margin-bottom: 12px;
+    }
+
+    .alert-success {
+        background: #ecfdf3;
+        color: #166534;
+        border: 1px solid #bbf7d0;
+    }
+
+    .alert-error {
+        background: #fef2f2;
+        color: #b91c1c;
+        border: 1px solid #fecdd3;
+    }
+
+    .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+    }
+
+    .hint {
+        font-size: 12px;
+        color: var(--text-muted);
+    }
+</style>
+
+<div class="page-header">
+    <div>
+        <h1>Your profile</h1>
+        <div class="subtitle">Manage your personal details, timezone, and password.</div>
+    </div>
+    <div>
         <a href="/dashboard/today">← Back to dashboard</a>
-        <a href="/logout">Logout</a>
+    </div>
+</div>
+
+<div class="card-grid">
+    <div class="card">
+        <div class="section-header">
+            <h2>Personal information</h2>
+            <span class="hint">Kept private to your account</span>
+        </div>
+
+        {% if profile_message %}
+        <div class="alert alert-success">{{ profile_message }}</div>
+        {% endif %}
+        {% if profile_error %}
+        <div class="alert alert-error">{{ profile_error }}</div>
+        {% endif %}
+
+        <form method="post" action="/profile">
+            <input type="hidden" name="form_type" value="profile">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+            <div class="form-field">
+                <label for="first_name">First name</label>
+                <input
+                    type="text"
+                    class="input"
+                    id="first_name"
+                    name="first_name"
+                    value="{{ user.first_name or '' }}"
+                    autocomplete="given-name"
+                >
+            </div>
+
+            <div class="form-field">
+                <label for="last_name">Last name</label>
+                <input
+                    type="text"
+                    class="input"
+                    id="last_name"
+                    name="last_name"
+                    value="{{ user.last_name or '' }}"
+                    autocomplete="family-name"
+                >
+            </div>
+
+            <div class="form-field">
+                <label for="email">Email</label>
+                <input
+                    type="text"
+                    class="input"
+                    id="email"
+                    name="email"
+                    value="{{ user.email }}"
+                    readonly
+                >
+            </div>
+
+            <div class="form-field">
+                <label for="timezone">Timezone</label>
+                <select id="timezone" name="timezone_name">
+                    {% for option in timezone_options %}
+                        <option value="{{ option.value }}" {% if option.value == selected_timezone %}selected{% endif %}>
+                            {{ option.label }}
+                        </option>
+                    {% endfor %}
+                </select>
+                <div class="hint">Pick the timezone used when showing your session times.</div>
+            </div>
+
+            <div class="actions">
+                <button class="btn btn-primary" type="submit">Save changes</button>
+            </div>
+        </form>
     </div>
 
-    <h1>Your Profile</h1>
-    <p><strong>Email:</strong> {{ user.email }}</p>
+    <div class="card">
+        <div class="section-header">
+            <h2>Update password</h2>
+            <span class="hint">Keep your account secure</span>
+        </div>
 
-    <form method="post" action="/profile">
-        <label for="timezone">Timezone (IANA name, e.g. "America/Denver")</label>
-        <input type="text"
-               id="timezone"
-               name="timezone_name"
-               value="{{ user.timezone or 'UTC' }}"
-               placeholder="America/Denver">
-
-        <button type="submit">Save changes</button>
-
-        {% if message %}
-        <div class="message">{{ message }}</div>
+        {% if password_message %}
+        <div class="alert alert-success">{{ password_message }}</div>
         {% endif %}
-    </form>
+        {% if password_error %}
+        <div class="alert alert-error">{{ password_error }}</div>
+        {% endif %}
+
+        <form method="post" action="/profile">
+            <input type="hidden" name="form_type" value="password">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+            <div class="form-field">
+                <label for="current_password">Current password</label>
+                <input
+                    type="password"
+                    class="input"
+                    id="current_password"
+                    name="current_password"
+                    autocomplete="current-password"
+                    required
+                >
+            </div>
+
+            <div class="form-field">
+                <label for="new_password">New password</label>
+                <input
+                    type="password"
+                    class="input"
+                    id="new_password"
+                    name="new_password"
+                    autocomplete="new-password"
+                    required
+                >
+                <div class="hint">Use at least 12 characters with a mix of upper/lowercase, numbers, and symbols.</div>
+            </div>
+
+            <div class="form-field">
+                <label for="new_password_confirm">Confirm new password</label>
+                <input
+                    type="password"
+                    class="input"
+                    id="new_password_confirm"
+                    name="new_password_confirm"
+                    autocomplete="new-password"
+                    required
+                >
+            </div>
+
+            <div class="actions">
+                <button class="btn btn-primary" type="submit">Update password</button>
+            </div>
+        </form>
+    </div>
 </div>
-</body>
-</html>
+{% endblock %}

--- a/raterhub-tracker/app/templates/register.html
+++ b/raterhub-tracker/app/templates/register.html
@@ -105,6 +105,24 @@
 
     <form method="post" action="/register">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <label for="first_name">First name (optional)</label>
+        <input
+            type="text"
+            id="first_name"
+            name="first_name"
+            value="{{ first_name or '' }}"
+            autocomplete="given-name"
+        >
+
+        <label for="last_name">Last name (optional)</label>
+        <input
+            type="text"
+            id="last_name"
+            name="last_name"
+            value="{{ last_name or '' }}"
+            autocomplete="family-name"
+        >
+
         <label for="email">Email</label>
         <input
             type="email"

--- a/raterhub-tracker/readme.md
+++ b/raterhub-tracker/readme.md
@@ -71,7 +71,7 @@ The backend computes timing stats per question and persists each session.
 
 - `/dashboard/today` — View today’s sessions, timing, pace emojis, and scores
 - `/dashboard/sessions/<id>` — Inspect each question inside a session
-- `/profile` — Set your preferred timezone for local time display
+- `/profile` — Manage personal details, timezone, and password
 
 ---
 
@@ -90,6 +90,18 @@ The backend computes timing stats per question and persists each session.
 - CSRF tokens for login/registration flows
 - Passwords hashed with bcrypt
 - Sessions cannot be created by non-NEXT events
+
+---
+
+## 🗄️ Database migration for name fields
+
+If you're upgrading an existing deployment, run the helper script to add the
+`first_name` and `last_name` columns to the `users` table (safe to re-run):
+
+```bash
+SECRET_KEY=your-secret DATABASE_URL=postgresql+psycopg2://... \\
+    python scripts/add_user_name_columns.py
+```
 
 ---
 

--- a/raterhub-tracker/scripts/add_user_name_columns.py
+++ b/raterhub-tracker/scripts/add_user_name_columns.py
@@ -1,0 +1,74 @@
+"""Ensure the users table has first_name and last_name columns.
+
+This lightweight migration script is intended for production deployments.
+It checks whether the columns already exist and adds them if missing. The
+script is safe to re-run.
+
+Usage (from repo root):
+    SECRET_KEY=... DATABASE_URL=... python scripts/add_user_name_columns.py
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Iterable
+
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy.engine import Engine
+
+from app.database import engine
+
+
+def _table_exists(engine: Engine, table: str) -> bool:
+    inspector = inspect(engine)
+    return inspector.has_table(table)
+
+
+def _has_column(engine: Engine, table: str, column: str) -> bool:
+    inspector = inspect(engine)
+    try:
+        columns: Iterable[dict] = inspector.get_columns(table)
+    except NoSuchTableError:
+        return False
+
+    return any(col.get("name") == column for col in columns)
+
+
+def _add_column(engine: Engine, column_name: str) -> None:
+    dialect = engine.dialect.name
+
+    if dialect == "postgresql":
+        ddl = text(
+            f"ALTER TABLE users ADD COLUMN IF NOT EXISTS {column_name} VARCHAR(255) DEFAULT '';"
+        )
+    else:
+        # SQLite supports ADD COLUMN without IF NOT EXISTS; we guard with inspector instead.
+        ddl = text(
+            f"ALTER TABLE users ADD COLUMN {column_name} VARCHAR(255) DEFAULT '';"
+        )
+
+    with engine.begin() as conn:
+        conn.execute(ddl)
+
+
+if __name__ == "__main__":
+    if not _table_exists(engine, "users"):
+        print("Users table not found. Ensure the database is initialized before running this script.")
+        sys.exit(1)
+
+    missing_columns = [
+        name
+        for name in ("first_name", "last_name")
+        if not _has_column(engine, "users", name)
+    ]
+
+    if not missing_columns:
+        print("Users table already has first_name and last_name columns. Nothing to do.")
+        sys.exit(0)
+
+    for column in missing_columns:
+        print(f"Adding column: {column}")
+        _add_column(engine, column)
+
+    print("Migration complete.")


### PR DESCRIPTION
## Summary
- add an idempotent helper script to backfill first_name and last_name columns on existing user tables
- document the profile page updates and how to run the migration script during upgrades

## Testing
- SECRET_KEY=test python -m pytest
- SECRET_KEY=test DATABASE_URL=sqlite:///./manual_registration.db uvicorn app.main:app --port 8001 --log-level warning (manual registration exercised via requests)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b50cb190c832ea2e20e7037ed670a)