### PR TITLE
Add nginx option and manual setup helper

### DIFF
--- a/raterhub-tracker/docker-compose.yml
+++ b/raterhub-tracker/docker-compose.yml
@@ -36,5 +36,22 @@ services:
       DATABASE_URL: postgresql+psycopg2://raterhub:super-secret-db-password@db:5432/raterhub
     entrypoint: ["/app/entrypoint.sh"]
 
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: raterhub-nginx
+    depends_on:
+      - web
+    profiles:
+      - nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider --quiet http://127.0.0.1/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
 volumes:
   raterhub_pgdata:

--- a/raterhub-tracker/documentation.md
+++ b/raterhub-tracker/documentation.md
@@ -18,7 +18,26 @@ RaterHub Tracker is a FastAPI application for session-based productivity trackin
    ```
 3. **Docker Compose**
    ```bash
-   docker-compose up --build
+   docker compose up --build           # FastAPI on :8000
+   docker compose --profile nginx up   # Adds nginx reverse proxy on :80
+   ```
+
+   The optional nginx service reads `nginx/default.conf` and forwards traffic to
+   the `web` container while preserving forwarded headers for proper request
+   logging.
+
+4. **Manual setup (no Docker)**
+   ```bash
+   bash scripts/manual_setup.sh
+   ```
+
+   The helper script creates `app/.venv`, installs requirements, and writes a
+   starter `.env` if one does not yet exist. Once it completes, activate the
+   virtual environment and start the app from the `app/` directory:
+
+   ```bash
+   source app/.venv/bin/activate
+   uvicorn main:app --host 0.0.0.0 --port 8000
    ```
 
 ## Configuration

--- a/raterhub-tracker/entrypoint.sh
+++ b/raterhub-tracker/entrypoint.sh
@@ -12,4 +12,4 @@ echo "Database is ready."
 # You can hook Alembic or similar here in future
 
 # Start the app
-exec uvicorn app.main:app --host 0.0.0.0 --port 8000
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips="*"

--- a/raterhub-tracker/nginx/default.conf
+++ b/raterhub-tracker/nginx/default.conf
@@ -1,0 +1,20 @@
+upstream raterhub_app {
+    server web:8000;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    client_max_body_size 10m;
+
+    location / {
+        proxy_pass http://raterhub_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+        proxy_buffering off;
+    }
+}

--- a/raterhub-tracker/readme.md
+++ b/raterhub-tracker/readme.md
@@ -40,6 +40,34 @@ docker build -t raterhub-tracker .
 docker run --rm -p 8000:8000 --env-file .env raterhub-tracker
 ```
 
+### Docker Compose (with optional nginx reverse proxy)
+
+```bash
+docker compose up --build           # FastAPI available on :8000
+docker compose --profile nginx up   # Adds nginx reverse proxy on :80
+```
+
+nginx proxies requests to the `web` container and forwards headers for correct
+client IP reporting. Its configuration lives in `nginx/default.conf` and is
+mounted read-only when the profile is enabled.
+
+### Manual setup (no Docker)
+
+If you prefer to run everything directly on your host:
+
+```bash
+bash scripts/manual_setup.sh
+```
+
+The script creates a virtual environment under `app/.venv`, installs
+dependencies, and writes a baseline `.env` if one is missing. Afterwards, run
+the server from the `app/` directory with:
+
+```bash
+source app/.venv/bin/activate
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
 ---
 
 ## 🔐 Environment Configuration (`.env`)

--- a/raterhub-tracker/scripts/manual_setup.sh
+++ b/raterhub-tracker/scripts/manual_setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script bootstraps a local (non-Docker) install with a Python virtualenv.
+# It creates a .env file if one does not exist and installs all dependencies.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_DIR="${ROOT_DIR}/app"
+VENV_DIR="${APP_DIR}/.venv"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to set up the environment." >&2
+  exit 1
+fi
+
+python3 -m venv "${VENV_DIR}"
+source "${VENV_DIR}/bin/activate"
+
+python -m pip install --upgrade pip
+python -m pip install -r "${ROOT_DIR}/requirements.txt"
+
+if [ ! -f "${ENV_FILE}" ]; then
+  cat <<'ENV_VARS' > "${ENV_FILE}"
+SECRET_KEY=change-me
+DATABASE_URL=sqlite:///./app.db
+ACCESS_TOKEN_EXPIRE_MINUTES=1440
+ALLOWED_ORIGINS=https://www.raterhub.com,https://api.raterhub.com
+DEBUG=false
+ENV_VARS
+  echo "Created ${ENV_FILE} with default values. Please review before running the app."
+else
+  echo "Using existing ${ENV_FILE}."
+fi
+
+echo "\nSetup complete. To start the app locally:"
+echo "  source ${VENV_DIR}/bin/activate"
+echo "  cd ${APP_DIR}"
+echo "  uvicorn main:app --host 0.0.0.0 --port 8000"


### PR DESCRIPTION
## Summary
- add an optional nginx reverse-proxy profile with configuration for Docker deployments
- configure uvicorn to honor forwarded headers when running behind the proxy
- provide a manual setup helper script and document the updated deployment options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b5d1b0564832ea078bf254bd9ee6f)