### PR TITLE
Add static landing page for end users

### DIFF
--- a/raterhub-tracker/static/index.html
+++ b/raterhub-tracker/static/index.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RaterHub Tracker — Landing</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header class="hero">
+        <div class="container">
+            <div class="header">
+                <div class="brand">
+                    <span>RaterHub Tracker</span>
+                    <div class="badge">Productivity insights for human raters</div>
+                </div>
+                <div class="pills-row">
+                    <span class="pill">Realtime tracking</span>
+                    <span class="pill">Chrome extension</span>
+                    <span class="pill">Advanced reporting</span>
+                </div>
+            </div>
+
+            <div class="hero-content">
+                <div>
+                    <h1>Own your rater day with precision.</h1>
+                    <p>Capture every task, see your pace in real time, and share reporting that helps you shine. RaterHub Tracker blends lightweight tracking with polished dashboards so you always know where you stand.</p>
+                    <div class="cta-row">
+                        <button class="button-primary">Start free trial</button>
+                        <button class="button-secondary">View reporting samples</button>
+                    </div>
+                </div>
+                <div class="placeholder-card">
+                    <div class="placeholder-label">Feature preview</div>
+                    <div class="placeholder-note">Add a hero screenshot of the dashboard here.</div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section">
+            <div class="container">
+                <h2 class="section-title">Why end users love it</h2>
+                <p class="section-subtitle">Everything is built to make your rater workflow smoother: track, report, and share updates without the busywork.</p>
+                <div class="cards-grid">
+                    <div class="card">
+                        <h3>Real-time tracking</h3>
+                        <p>Log sessions, tasks, and pacing with auto-calculated totals so you always know how you are trending.</p>
+                    </div>
+                    <div class="card">
+                        <h3>Chrome extension</h3>
+                        <p>Start, pause, and submit entries directly from your browser while you work. No tab switching required.</p>
+                    </div>
+                    <div class="card">
+                        <h3>Advanced reporting</h3>
+                        <p>Download summaries, share pace updates, and export data to CSV to keep your lead and team in sync.</p>
+                    </div>
+                    <div class="card">
+                        <h3>Secure by design</h3>
+                        <p>Single sign-on support, encrypted data, and role-based access keep your work information safe.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" style="background:#fbf9ff;">
+            <div class="container two-column">
+                <div>
+                    <h2 class="section-title">Feature highlights</h2>
+                    <p class="section-subtitle">Give everyone visibility with dashboards, weekly summaries, and simple exports.</p>
+                    <ul class="list">
+                        <li>
+                            <div class="icon">1</div>
+                            <div>
+                                <strong>Today dashboard.</strong> Track active minutes, tasks completed, and projected pace in one glance.
+                            </div>
+                        </li>
+                        <li>
+                            <div class="icon">2</div>
+                            <div>
+                                <strong>Session timelines.</strong> Break down your day by session to spot gaps and overages instantly.
+                            </div>
+                        </li>
+                        <li>
+                            <div class="icon">3</div>
+                            <div>
+                                <strong>Reports & downloads.</strong> Export CSVs, share weekly summaries, and keep your manager updated.
+                            </div>
+                        </li>
+                        <li>
+                            <div class="icon">4</div>
+                            <div>
+                                <strong>Browser controls.</strong> Use the extension to start timers, submit updates, and view stats without leaving your queue.
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+                <div class="placeholder-card">
+                    <div class="placeholder-label">Dashboard gallery</div>
+                    <div class="placeholder-note">Reserve this spot for a carousel of widget and dashboard screenshots.</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section">
+            <div class="container two-column">
+                <div>
+                    <h2 class="section-title">Quick start guide</h2>
+                    <p class="section-subtitle">Get up and running in minutes with simple steps for new and returning users.</p>
+                    <ul class="list">
+                        <li>
+                            <div class="icon">A</div>
+                            <div>
+                                <strong>Sign up.</strong> Click "Start free trial" and create your account with email and password. Confirm your email to secure your workspace.
+                            </div>
+                        </li>
+                        <li>
+                            <div class="icon">B</div>
+                            <div>
+                                <strong>Log in.</strong> Use your credentials to access the web app or sign in with your configured SSO provider.
+                            </div>
+                        </li>
+                        <li>
+                            <div class="icon">C</div>
+                            <div>
+                                <strong>Install the Chrome extension.</strong> Visit the Chrome Web Store listing, click "Add to Chrome," and pin it to your toolbar for quick access. Sign in once to sync with your account.
+                            </div>
+                        </li>
+                        <li>
+                            <div class="icon">D</div>
+                            <div>
+                                <strong>Start tracking.</strong> Launch your first session from the extension or the dashboard and watch your metrics populate instantly.
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+                <div class="card">
+                    <h3>Need a visual?</h3>
+                    <p>Add a short looping GIF of the sign-up and extension install flow here to show how fast onboarding is.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" style="background:#fbf9ff;">
+            <div class="container">
+                <h2 class="section-title">FAQ</h2>
+                <p class="section-subtitle">Answers to the most common questions about getting started and daily use.</p>
+                <div class="faq">
+                    <div class="faq-item">
+                        <h4>Can I track multiple projects?</h4>
+                        <p>Yes. Create projects or tags for each client or queue, and switch between them from the extension or dashboard.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h4>Do I need to keep a tab open for tracking?</h4>
+                        <p>No. The Chrome extension runs quietly while you work and syncs entries to the dashboard automatically.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h4>What if I forget to stop a session?</h4>
+                        <p>Use the timeline editor to trim sessions or add manual entries so your reports stay accurate.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h4>How do exports work?</h4>
+                        <p>Generate CSVs or PDFs from the reporting page with a date range, then share them with your lead or upload to your HR tools.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h4>Is my data secure?</h4>
+                        <p>We encrypt data at rest and in transit, and apply least-privilege access controls for your workspace.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            Built for RaterHub professionals who need accurate, shareable progress tracking.
+        </div>
+    </footer>
+</body>
+</html>

--- a/raterhub-tracker/static/styles.css
+++ b/raterhub-tracker/static/styles.css
@@ -1,0 +1,282 @@
+:root {
+    --bg-main: #f7f3ff;
+    --card-bg: #ffffff;
+    --accent: #6c5ce7;
+    --accent-soft: #a29bfe;
+    --accent-dark: #4834d4;
+    --accent-light: #dcd2ff;
+    --text-main: #2d2440;
+    --text-muted: #6c657e;
+    --border-subtle: #e4ddff;
+    --table-header: #f0e9ff;
+    --pill-bg: #f4f0ff;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Segoe UI", Arial, sans-serif;
+    background: radial-gradient(circle at top left, #fce1ff 0, var(--bg-main) 40%, #ffffff 100%);
+    color: var(--text-main);
+}
+
+.hero {
+    background: linear-gradient(135deg, rgba(108, 92, 231, 0.12), rgba(72, 52, 212, 0.08));
+    padding: 64px 0 52px;
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+.container {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 0 24px;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 40px;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-weight: 700;
+    font-size: 20px;
+    color: var(--accent-dark);
+}
+
+.badge {
+    background: var(--pill-bg);
+    padding: 6px 12px;
+    border-radius: 999px;
+    color: var(--accent-dark);
+    border: 1px solid var(--accent-light);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+}
+
+.hero-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 32px;
+    align-items: center;
+}
+
+.hero h1 {
+    margin: 0 0 12px;
+    font-size: 34px;
+    color: var(--accent-dark);
+}
+
+.hero p {
+    color: var(--text-muted);
+    margin: 0 0 20px;
+    line-height: 1.6;
+}
+
+.cta-row {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.button-primary {
+    background: linear-gradient(120deg, var(--accent), var(--accent-dark));
+    color: white;
+    border: none;
+    border-radius: 12px;
+    padding: 12px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 10px 24px rgba(108, 92, 231, 0.25);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.button-primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 28px rgba(108, 92, 231, 0.28);
+}
+
+.button-secondary {
+    background: white;
+    color: var(--accent-dark);
+    border: 1px solid var(--border-subtle);
+    border-radius: 12px;
+    padding: 12px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.05);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.button-secondary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.08);
+}
+
+.placeholder-card {
+    background: var(--card-bg);
+    border: 1px dashed var(--border-subtle);
+    border-radius: 18px;
+    padding: 28px;
+    box-shadow: 0 14px 38px rgba(0, 0, 0, 0.07);
+    text-align: center;
+    color: var(--text-muted);
+    min-height: 220px;
+}
+
+.section {
+    padding: 60px 0;
+}
+
+.section-title {
+    font-size: 26px;
+    color: var(--accent-dark);
+    margin: 0 0 12px;
+}
+
+.section-subtitle {
+    color: var(--text-muted);
+    margin: 0 0 28px;
+    line-height: 1.6;
+}
+
+.cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 18px;
+}
+
+.card {
+    background: var(--card-bg);
+    border-radius: 16px;
+    border: 1px solid var(--border-subtle);
+    box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+    padding: 20px 22px;
+}
+
+.card h3 {
+    margin: 0 0 10px;
+    color: var(--accent-dark);
+    font-size: 18px;
+}
+
+.card p {
+    margin: 0;
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.list li {
+    display: grid;
+    grid-template-columns: 28px 1fr;
+    gap: 10px;
+    align-items: flex-start;
+    padding: 12px;
+    background: #faf8ff;
+    border-radius: 12px;
+    border: 1px solid #ece4ff;
+}
+
+.list .icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 10px;
+    background: var(--accent-light);
+    display: grid;
+    place-items: center;
+    color: var(--accent-dark);
+    font-weight: 700;
+}
+
+.two-column {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 24px;
+    align-items: start;
+}
+
+.faq {
+    display: grid;
+    gap: 12px;
+}
+
+.faq-item {
+    border: 1px solid var(--border-subtle);
+    border-radius: 14px;
+    padding: 16px;
+    background: white;
+    box-shadow: 0 10px 22px rgba(0,0,0,0.04);
+}
+
+.faq-item h4 {
+    margin: 0 0 8px;
+    color: var(--accent-dark);
+}
+
+.faq-item p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.footer {
+    padding: 32px 0 40px;
+    text-align: center;
+    color: var(--text-muted);
+    border-top: 1px solid var(--border-subtle);
+    background: #fbf9ff;
+}
+
+.pills-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.pill {
+    display: inline-block;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: var(--accent-light);
+    color: var(--accent-dark);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.placeholder-label {
+    font-weight: 700;
+    color: var(--accent-dark);
+    margin-bottom: 6px;
+}
+
+.placeholder-note {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+    .header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .hero {
+        padding: 48px 0 36px;
+    }
+}


### PR DESCRIPTION
## Summary
- add a static landing page highlighting tracking, extension, and reporting features
- include quick-start documentation for signing up, logging in, and installing the Chrome extension
- provide FAQ section and styled placeholders for feature screenshots

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b605c52ac832ebdf1d120a402c696)