### PR TITLE
Simplify open source landing page

### DIFF
--- a/raterhub-tracker/static/index.html
+++ b/raterhub-tracker/static/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RaterHub Tracker — Open Source Landing</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header class="hero">
+        <div class="container">
+            <div class="top-bar">
+                <div class="brand">RaterHub Tracker</div>
+                <div class="badge">Free & open source for Google raters</div>
+            </div>
+            <div class="hero-grid">
+                <div class="hero-copy">
+                    <p class="eyebrow">Community-built • Transparent • No paywalls</p>
+                    <h1>Stay organized with a calm, open tracking dashboard.</h1>
+                    <p class="lead">
+                        RaterHub Tracker keeps daily tasks, pacing, and reports in one place. Everything is open
+                        source so the community can improve it together.
+                    </p>
+                    <div class="actions">
+                        <button class="button primary">View the project</button>
+                        <button class="button ghost">Read the docs</button>
+                    </div>
+                    <div class="meta">
+                        <span>Built for the betterment of all Google raters.</span>
+                        <span class="dot">•</span>
+                        <span>Browser extension included.</span>
+                    </div>
+                </div>
+                <div class="placeholder">
+                    <div class="placeholder-title">Dashboard preview</div>
+                    <div class="placeholder-body">Add a screenshot of the homepage or daily dashboard here.</div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section">
+            <div class="container">
+                <h2 class="section-title">What you can do</h2>
+                <div class="feature-grid">
+                    <div class="feature">
+                        <div class="feature-icon">⏱</div>
+                        <div>
+                            <h3>Track calmly</h3>
+                            <p>Capture sessions and tasks without clutter. See pace updates as you work.</p>
+                        </div>
+                    </div>
+                    <div class="feature">
+                        <div class="feature-icon">🧭</div>
+                        <div>
+                            <h3>Use the extension</h3>
+                            <p>Start and pause entries from Chrome while staying on your queue.</p>
+                        </div>
+                    </div>
+                    <div class="feature">
+                        <div class="feature-icon">📊</div>
+                        <div>
+                            <h3>Share simple reports</h3>
+                            <p>Download CSVs or share summaries to keep teams aligned.</p>
+                        </div>
+                    </div>
+                    <div class="feature">
+                        <div class="feature-icon">🔒</div>
+                        <div>
+                            <h3>Own your data</h3>
+                            <p>Open source code, transparent choices, and community-reviewed updates.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section muted">
+            <div class="container two-col">
+                <div>
+                    <h2 class="section-title">Quick start</h2>
+                    <ul class="steps">
+                        <li>
+                            <strong>Sign up.</strong> Create your account from the web app. Email confirmation keeps access secure.
+                        </li>
+                        <li>
+                            <strong>Log in.</strong> Return anytime with your credentials or configured SSO.
+                        </li>
+                        <li>
+                            <strong>Install the Chrome extension.</strong> Find it on the Chrome Web Store, add to Chrome, and pin it.
+                        </li>
+                        <li>
+                            <strong>Track.</strong> Start a session from the extension or dashboard and let the metrics update.
+                        </li>
+                    </ul>
+                </div>
+                <div class="placeholder soft">
+                    <div class="placeholder-title">Onboarding snippet</div>
+                    <div class="placeholder-body">Drop a short GIF showing sign-up and extension install here.</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section">
+            <div class="container two-col">
+                <div>
+                    <h2 class="section-title">Docs at a glance</h2>
+                    <div class="doc-card">
+                        <h3>Signing up</h3>
+                        <p>Open the app, choose "Create account," and confirm your email before signing in.</p>
+                    </div>
+                    <div class="doc-card">
+                        <h3>Logging in</h3>
+                        <p>Use your email and password or the SSO option configured by your team.</p>
+                    </div>
+                    <div class="doc-card">
+                        <h3>Installing the browser extension</h3>
+                        <p>Visit the Chrome Web Store listing, select "Add to Chrome," then sign in once to sync.</p>
+                    </div>
+                </div>
+                <div class="placeholder">
+                    <div class="placeholder-title">Reporting view</div>
+                    <div class="placeholder-body">Add a screenshot of the reporting page or CSV export dialog.</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section muted">
+            <div class="container">
+                <h2 class="section-title">FAQ</h2>
+                <div class="faq">
+                    <div class="faq-item">
+                        <h4>Is it really free?</h4>
+                        <p>Yes. The project is open source and intended to help every Google rater.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h4>Do I need to keep a tab open?</h4>
+                        <p>No. The Chrome extension keeps tracking in sync while you work.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h4>Can I edit mistakes?</h4>
+                        <p>Use the timeline to trim or adjust entries before exporting.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h4>What about my data?</h4>
+                        <p>The code is public, and we favor minimal data collection with transparent defaults.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">RaterHub Tracker is a community effort. Pull requests welcome.</div>
+    </footer>
+</body>
+</html>

--- a/raterhub-tracker/static/styles.css
+++ b/raterhub-tracker/static/styles.css
@@ -1,0 +1,288 @@
+:root {
+    --bg: #0f0a1f;
+    --panel: #17112e;
+    --muted: #241b3f;
+    --accent: #8c5bff;
+    --accent-2: #c59bff;
+    --text: #f5f3ff;
+    --text-muted: #c7c3d9;
+    --border: #281f45;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    background: radial-gradient(circle at 20% 20%, rgba(140, 91, 255, 0.15), transparent 30%),
+        radial-gradient(circle at 80% 0%, rgba(197, 155, 255, 0.12), transparent 32%),
+        var(--bg);
+    color: var(--text);
+}
+
+.container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 24px;
+}
+
+.hero {
+    padding: 52px 0 44px;
+    background: linear-gradient(180deg, rgba(23, 17, 46, 0.92), rgba(23, 17, 46, 0.85));
+    border-bottom: 1px solid var(--border);
+}
+
+.top-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 28px;
+}
+
+.brand {
+    font-weight: 700;
+    letter-spacing: 0.4px;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: rgba(140, 91, 255, 0.12);
+    color: var(--accent-2);
+    font-size: 13px;
+}
+
+.hero-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 28px;
+    align-items: start;
+}
+
+.hero-copy h1 {
+    margin: 6px 0 14px;
+    font-size: 32px;
+    line-height: 1.25;
+}
+
+.eyebrow {
+    margin: 0;
+    color: var(--accent-2);
+    letter-spacing: 0.2px;
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.lead {
+    margin: 0 0 18px;
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.actions {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 14px;
+    flex-wrap: wrap;
+}
+
+.button {
+    border-radius: 10px;
+    padding: 11px 16px;
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--text);
+}
+
+.button.primary {
+    background: linear-gradient(120deg, var(--accent), var(--accent-2));
+    border-color: rgba(255, 255, 255, 0.08);
+    color: #120b26;
+}
+
+.button.ghost {
+    border-color: var(--border);
+    color: var(--text);
+}
+
+.button:hover {
+    transform: translateY(-1px);
+    transition: transform 120ms ease;
+}
+
+.meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.dot {
+    opacity: 0.5;
+}
+
+.placeholder {
+    border: 1px dashed var(--border);
+    border-radius: 14px;
+    padding: 18px;
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--text-muted);
+    min-height: 180px;
+}
+
+.placeholder.soft {
+    background: rgba(140, 91, 255, 0.04);
+}
+
+.placeholder-title {
+    color: var(--text);
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.placeholder-body {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.section {
+    padding: 48px 0;
+    background: var(--bg);
+}
+
+.section.muted {
+    background: var(--muted);
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+}
+
+.section-title {
+    margin: 0 0 18px;
+    font-size: 24px;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 14px;
+}
+
+.feature {
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    gap: 10px;
+    padding: 14px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border);
+}
+
+.feature h3 {
+    margin: 0 0 6px;
+}
+
+.feature p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.feature-icon {
+    width: 44px;
+    height: 44px;
+    display: grid;
+    place-items: center;
+    border-radius: 10px;
+    background: rgba(140, 91, 255, 0.15);
+    color: var(--accent-2);
+    font-size: 18px;
+}
+
+.two-col {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 18px;
+    align-items: start;
+}
+
+.steps {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 10px;
+}
+
+.steps li {
+    padding: 12px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-muted);
+}
+
+.doc-card {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 14px;
+    margin-bottom: 10px;
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.doc-card h3 {
+    margin: 0 0 6px;
+}
+
+.doc-card p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.faq {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 12px;
+}
+
+.faq-item {
+    padding: 14px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.faq-item h4 {
+    margin: 0 0 6px;
+}
+
+.faq-item p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.footer {
+    padding: 28px 0 36px;
+    text-align: center;
+    color: var(--text-muted);
+    border-top: 1px solid var(--border);
+    background: #0c081b;
+}
+
+@media (max-width: 640px) {
+    .top-bar {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .hero-copy h1 {
+        font-size: 28px;
+    }
+}


### PR DESCRIPTION
## Summary
- restyle the static landing page with a calmer purple palette inspired by Kubernetes
- shift messaging to emphasize the free, open-source project for Google raters
- simplify sections with concise features, quick start steps, and updated placeholders for visuals

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b605c52ac832ebdf1d120a402c696)