### PR TITLE
Fix widget collapse height

### DIFF
--- a/extension/content/widget.js
+++ b/extension/content/widget.js
@@ -38,6 +38,10 @@
     sessionStatsEl,
     resizeObserver;
 
+  // Track expanded sizing so collapse can shrink the widget footprint
+  let expandedMinHeight = null;
+  let expandedHeight = null;
+
   // --- Drag state ---
   let isDragging = false;
   let dragStartMouseX = 0;
@@ -161,6 +165,14 @@
     if (isCollapsed) {
       bodyContainer.style.display = "none";
       toggleBtn.textContent = "▴";
+      if (!expandedMinHeight) {
+        expandedMinHeight = widget.style.minHeight;
+      }
+      if (!expandedHeight) {
+        expandedHeight = widget.style.height;
+      }
+      widget.style.minHeight = "0";
+      widget.style.height = "auto";
       if (collapsedTimerEl) {
         collapsedTimerEl.style.display = "inline-flex";
         collapsedTimerEl.style.alignItems = "center";
@@ -168,6 +180,8 @@
     } else {
       bodyContainer.style.display = "block";
       toggleBtn.textContent = "▾";
+      widget.style.minHeight = expandedMinHeight || "200px";
+      widget.style.height = expandedHeight || "";
       if (collapsedTimerEl) {
         collapsedTimerEl.style.display = "none";
       }


### PR DESCRIPTION
## Summary
- collapse now removes the saved minimum height so the widget footprint shrinks fully
- store expanded height values and restore them when the widget reopens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b6ca4a1ac832e9dd351e9e0ed85f8)