### PR TITLE
Improve widget collapse sizing and auto-login from popup

### DIFF
--- a/extension/content/widget.js
+++ b/extension/content/widget.js
@@ -38,6 +38,10 @@
     sessionStatsEl,
     resizeObserver;
 
+  // Track expanded sizing so collapse can shrink the widget footprint
+  let expandedMinHeight = null;
+  let expandedHeight = null;
+
   // --- Drag state ---
   let isDragging = false;
   let dragStartMouseX = 0;
@@ -159,8 +163,13 @@
   function applyCollapsedState() {
     if (!bodyContainer || !toggleBtn) return;
     if (isCollapsed) {
+      const computed = window.getComputedStyle(widget);
+      expandedMinHeight = widget.style.minHeight || computed.minHeight;
+      expandedHeight = widget.style.height || computed.height;
       bodyContainer.style.display = "none";
       toggleBtn.textContent = "▴";
+      widget.style.minHeight = "0";
+      widget.style.height = "auto";
       if (collapsedTimerEl) {
         collapsedTimerEl.style.display = "inline-flex";
         collapsedTimerEl.style.alignItems = "center";
@@ -168,6 +177,8 @@
     } else {
       bodyContainer.style.display = "block";
       toggleBtn.textContent = "▾";
+      widget.style.minHeight = expandedMinHeight || "200px";
+      widget.style.height = expandedHeight || "";
       if (collapsedTimerEl) {
         collapsedTimerEl.style.display = "none";
       }
@@ -215,16 +226,6 @@
     title.style.fontWeight = "700";
     title.style.fontSize = "13px";
     title.style.color = "#0f172a";
-
-    collapsedTimerEl = document.createElement("span");
-    collapsedTimerEl.textContent = "00:00";
-    collapsedTimerEl.style.fontSize = "11px";
-    collapsedTimerEl.style.fontWeight = "700";
-    collapsedTimerEl.style.color = "#4b5563";
-    collapsedTimerEl.style.display = "none";
-
-    titleWrapper.appendChild(title);
-    titleWrapper.appendChild(collapsedTimerEl);
 
     collapsedTimerEl = document.createElement("span");
     collapsedTimerEl.textContent = "00:00";

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -11,7 +11,23 @@ async function loadPopupData() {
     includeLastStatus: true,
   });
 
-  if (statusResp?.authenticated) {
+  let isAuthenticated = Boolean(statusResp?.authenticated);
+
+  if (!isAuthenticated && statusResp?.hasCredentials) {
+    authStatusEl.textContent = "Signing in…";
+    authStatusEl.style.color = "#6b7280";
+    const loginResp = await chrome.runtime.sendMessage({ type: "LOGIN" });
+    isAuthenticated = Boolean(loginResp?.ok);
+    if (isAuthenticated) {
+      authStatusEl.textContent = "Logged in";
+      authStatusEl.style.color = "#15803d";
+      lastStatusEl.textContent = "Logged in";
+    } else {
+      authStatusEl.textContent = "Login failed";
+      authStatusEl.style.color = "#b91c1c";
+      lastStatusEl.textContent = loginResp?.error ? `Error: ${loginResp.error}` : "Login failed";
+    }
+  } else if (isAuthenticated) {
     authStatusEl.textContent = "Logged in";
     authStatusEl.style.color = "#15803d";
   } else {
@@ -19,9 +35,9 @@ async function loadPopupData() {
     authStatusEl.style.color = "#b91c1c";
   }
 
-  if (statusResp?.lastStatus) {
+  if (statusResp?.lastStatus && !isAuthenticated) {
     lastStatusEl.textContent = statusResp.lastStatus;
-  } else {
+  } else if (!lastStatusEl.textContent || lastStatusEl.textContent === "—") {
     lastStatusEl.textContent = "No recent activity";
   }
 


### PR DESCRIPTION
## Summary
- capture widget sizing before collapse to restore the expanded footprint accurately
- remove duplicate collapsed timer element in the widget header
- auto-trigger login from the popup when saved credentials exist, avoiding the options flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b6ca4a1ac832e9dd351e9e0ed85f8)