### PR TITLE
Improve timezone normalization in reporting service

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer package."""

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List
+
+from sqlalchemy.orm import Session as OrmSession
+
+from app.db_models import User
+from app.main import build_day_summary, build_session_summary, get_user_tz
+from app.models import SessionSummary, TodaySummary
+
+
+class UserNotFoundError(Exception):
+    """Raised when the requested user_id does not exist."""
+
+
+class DailyReport:
+    """Container for a single day's report in the user's timezone."""
+
+    def __init__(
+        self,
+        date: datetime,
+        day_summary: TodaySummary,
+        session_summaries: List[SessionSummary],
+    ) -> None:
+        self.date = date
+        self.day_summary = day_summary
+        self.session_summaries = session_summaries
+
+
+class WeeklyReport:
+    """Container for a full week's worth of daily reports."""
+
+    def __init__(
+        self,
+        week_start: datetime,
+        week_end: datetime,
+        daily_reports: List[DailyReport],
+        totals: Dict[str, float],
+    ) -> None:
+        self.week_start = week_start
+        self.week_end = week_end
+        self.daily_reports = daily_reports
+        self.totals = totals
+
+
+def _get_user_or_raise(db: OrmSession, user_id: int) -> User:
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise UserNotFoundError(f"User {user_id} not found")
+    return user
+
+
+def _normalize_local_midnight(date: datetime, tz) -> datetime:
+    """Return the given datetime snapped to the user's local midnight."""
+
+    if date.tzinfo is not None:
+        local_date = date.astimezone(tz)
+    else:
+        local_date = datetime(date.year, date.month, date.day, tzinfo=tz)
+
+    return datetime(local_date.year, local_date.month, local_date.day, tzinfo=tz)
+
+
+def build_daily_report(
+    db: OrmSession, user_id: int, date: datetime, *, user: User | None = None
+) -> DailyReport:
+    """
+    Build a daily report for the given user on the specified date (interpreted
+    in the user's timezone). Includes the JSON day summary and per-session
+    summaries for the sessions that started on that local day.
+    """
+
+    user = user or _get_user_or_raise(db, user_id)
+    tz = get_user_tz(user)
+    local_date = _normalize_local_midnight(date, tz)
+
+    day_summary = build_day_summary(db, user, local_date)
+    session_summaries: List[SessionSummary] = []
+    for session_item in day_summary.sessions:
+        session_summaries.append(
+            build_session_summary(db, user, session_item.session_id)
+        )
+
+    return DailyReport(
+        date=day_summary.date,
+        day_summary=day_summary,
+        session_summaries=session_summaries,
+    )
+
+
+def build_weekly_report(
+    db: OrmSession,
+    user_id: int,
+    week_start: datetime,
+) -> WeeklyReport:
+    """
+    Build a weekly report starting at the given local date for the user.
+
+    The seven-day window is computed in the user's timezone, and each day reuses
+    the daily summary/session helpers for consistency.
+    """
+    user = _get_user_or_raise(db, user_id)
+    tz = get_user_tz(user)
+
+    local_week_start = _normalize_local_midnight(week_start, tz)
+    local_week_end = local_week_start + timedelta(days=7)
+
+    daily_reports: List[DailyReport] = []
+    for offset in range(7):
+        day_date = local_week_start + timedelta(days=offset)
+        daily_reports.append(
+            build_daily_report(
+                db,
+                user_id,
+                day_date,
+                user=user,
+            )
+        )
+
+    totals = {
+        "total_sessions": sum(r.day_summary.total_sessions for r in daily_reports),
+        "total_questions": sum(r.day_summary.total_questions for r in daily_reports),
+        "total_active_seconds": sum(
+            r.day_summary.total_active_seconds for r in daily_reports
+        ),
+    }
+
+    return WeeklyReport(
+        week_start=local_week_start,
+        week_end=local_week_end,
+        daily_reports=daily_reports,
+        totals=totals,
+    )

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,228 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as OrmSession, sessionmaker
+
+from app.db_models import Base, Question, Session as DbSession, User
+from app.services.reporting import build_daily_report, build_weekly_report
+
+
+def make_db_session() -> OrmSession:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_build_daily_report_respects_user_timezone():
+    db = make_db_session()
+
+    user = User(
+        external_id="u1",
+        email="tz-user@example.com",
+        timezone="America/Los_Angeles",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    session = DbSession(
+        user_id=user.id,
+        started_at=datetime(2024, 1, 2, 7, 30, 0),  # 2024-01-01 23:30 PST
+        ended_at=datetime(2024, 1, 2, 7, 45, 0),
+        is_active=False,
+        target_minutes_per_question=5.5,
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    question = Question(
+        session_id=session.id,
+        index=1,
+        started_at=session.started_at,
+        ended_at=session.ended_at,
+        raw_seconds=900.0,
+        active_seconds=600.0,
+    )
+    db.add(question)
+    db.commit()
+
+    report = build_daily_report(db, user.id, datetime(2024, 1, 1))
+
+    hour_23_bucket = next(b for b in report.day_summary.hourly_activity if b.hour == 23)
+    assert hour_23_bucket.total_questions == 1
+    assert report.day_summary.total_sessions == 1
+    assert report.session_summaries[0].session_id == session.public_id
+
+    db.close()
+
+
+def test_build_daily_report_normalizes_timezone_aware_dates():
+    db = make_db_session()
+
+    user = User(
+        external_id="aware",
+        email="aware@example.com",
+        timezone="Asia/Tokyo",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    session = DbSession(
+        user_id=user.id,
+        started_at=datetime(2023, 12, 31, 18, 30, 0),  # 2024-01-01 03:30 JST
+        ended_at=datetime(2023, 12, 31, 18, 45, 0),
+        is_active=False,
+        target_minutes_per_question=5.5,
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    db.add(
+        Question(
+            session_id=session.id,
+            index=1,
+            started_at=session.started_at,
+            ended_at=session.ended_at,
+            raw_seconds=600.0,
+            active_seconds=480.0,
+        )
+    )
+    db.commit()
+
+    report = build_daily_report(
+        db,
+        user.id,
+        datetime(2023, 12, 31, 18, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert report.day_summary.date.day == 1
+    assert report.day_summary.total_sessions == 1
+    assert report.day_summary.total_questions == 1
+
+    db.close()
+
+
+def test_build_weekly_report_groups_daily_reports():
+    db = make_db_session()
+
+    user = User(
+        external_id="u1",
+        email="weekly@example.com",
+        timezone="Asia/Kolkata",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    first_session = DbSession(
+        user_id=user.id,
+        started_at=datetime(2024, 1, 1, 18, 30, 0),  # Local 2024-01-02 00:00 IST
+        ended_at=datetime(2024, 1, 1, 18, 45, 0),
+        is_active=False,
+        target_minutes_per_question=5.5,
+    )
+    second_session = DbSession(
+        user_id=user.id,
+        started_at=datetime(2024, 1, 3, 4, 0, 0),  # Local 2024-01-03 09:30 IST
+        ended_at=datetime(2024, 1, 3, 4, 20, 0),
+        is_active=False,
+        target_minutes_per_question=5.5,
+    )
+    db.add_all([first_session, second_session])
+    db.commit()
+    db.refresh(first_session)
+    db.refresh(second_session)
+
+    db.add_all(
+        [
+            Question(
+                session_id=first_session.id,
+                index=1,
+                started_at=first_session.started_at,
+                ended_at=first_session.ended_at,
+                raw_seconds=900.0,
+                active_seconds=600.0,
+            ),
+            Question(
+                session_id=second_session.id,
+                index=1,
+                started_at=second_session.started_at,
+                ended_at=second_session.ended_at,
+                raw_seconds=600.0,
+                active_seconds=420.0,
+            ),
+        ]
+    )
+    db.commit()
+
+    weekly_report = build_weekly_report(db, user.id, datetime(2024, 1, 1))
+
+    assert len(weekly_report.daily_reports) == 7
+    jan_2_report = next(
+        r for r in weekly_report.daily_reports if r.day_summary.date.day == 2
+    )
+    jan_3_report = next(
+        r for r in weekly_report.daily_reports if r.day_summary.date.day == 3
+    )
+
+    assert jan_2_report.day_summary.total_sessions == 1
+    assert jan_3_report.day_summary.total_sessions == 1
+    assert weekly_report.totals["total_questions"] == 2
+    assert weekly_report.totals["total_sessions"] == 2
+
+    db.close()
+
+
+def test_build_weekly_report_normalizes_start_date_timezone():
+    db = make_db_session()
+
+    user = User(
+        external_id="weekly-aware",
+        email="weekly-aware@example.com",
+        timezone="America/New_York",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    session = DbSession(
+        user_id=user.id,
+        started_at=datetime(2024, 1, 7, 15, 0, 0),  # 2024-01-07 10:00 EST
+        ended_at=datetime(2024, 1, 7, 15, 20, 0),
+        is_active=False,
+        target_minutes_per_question=5.5,
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    db.add(
+        Question(
+            session_id=session.id,
+            index=1,
+            started_at=session.started_at,
+            ended_at=session.ended_at,
+            raw_seconds=900.0,
+            active_seconds=840.0,
+        )
+    )
+    db.commit()
+
+    weekly_report = build_weekly_report(
+        db,
+        user.id,
+        datetime(2024, 1, 8, 2, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert weekly_report.week_start.day == 7
+    jan7_report = next(
+        r for r in weekly_report.daily_reports if r.day_summary.date.day == 7
+    )
+    assert jan7_report.day_summary.total_sessions == 1
+    assert weekly_report.totals["total_sessions"] == 1
+    assert weekly_report.totals["total_questions"] == 1
+
+    db.close()


### PR DESCRIPTION
## Summary
- normalize daily and weekly reporting boundaries by converting inputs to the user's timezone
- allow reuse of loaded user objects when building daily reports to avoid redundant lookups
- add tests covering timezone-aware date inputs for daily and weekly report builders

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b9b1184b0832e94bacd636c0fa244)