### PR TITLE
Add migration helper for email audit table

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -38,4 +38,12 @@ class Settings:
         if origin:
             ALLOWED_ORIGINS.append(origin)
 
+    # Email delivery
+    EMAIL_SENDING_ENABLED = _env_flag("EMAIL_SENDING_ENABLED", default=False)
+    EMAIL_SMTP_HOST = os.getenv("EMAIL_SMTP_HOST")
+    EMAIL_SMTP_PORT = int(os.getenv("EMAIL_SMTP_PORT", 587))
+    EMAIL_SMTP_USERNAME = os.getenv("EMAIL_SMTP_USERNAME")
+    EMAIL_SMTP_PASSWORD = os.getenv("EMAIL_SMTP_PASSWORD")
+    EMAIL_FROM_ADDRESS = os.getenv("EMAIL_FROM_ADDRESS", "reports@example.com")
+
 settings = Settings()

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     UniqueConstraint,
+    Date,
 )
 from sqlalchemy.orm import relationship, declarative_base
 
@@ -37,6 +38,9 @@ class User(Base):
 
     # NEW: user timezone (IANA string, e.g. "America/Denver")
     timezone = Column(String, nullable=False, default="UTC")
+
+    # Email preferences
+    wants_report_emails = Column(Boolean, nullable=False, default=False)
 
     # Relationships
     sessions = relationship(
@@ -147,3 +151,18 @@ class LoginAttempt(Base):
     locked_until = Column(DateTime, nullable=True)
 
     __table_args__ = (UniqueConstraint("key_type", "key_value", name="uix_login_attempt_key"),)
+
+
+class ReportAudit(Base):
+    __tablename__ = "report_audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    report_scope = Column(String, nullable=False)  # "daily" or "weekly"
+    report_format = Column(String, nullable=False)  # "csv", "pdf", or "email"
+    report_date = Column(Date, nullable=False)
+    triggered_by = Column(String, nullable=False)  # "user_download" or "scheduler"
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    details = Column(String, nullable=True)
+
+    user = relationship("User")

--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,7 @@ from .db_models import (
     Question,
     PasswordHistory,
     LoginAttempt,
+    ReportAudit,
 )
 from .models import (
     EventIn,
@@ -57,6 +58,7 @@ from .auth import (
     validate_password_policy,
 )
 from .config import settings
+from .services.audit import log_report_event
 
 # ============================================================
 # FastAPI initialization
@@ -1315,6 +1317,15 @@ def download_daily_report(
         "Content-Disposition": f'attachment; filename="{filename}"'
     }
 
+    log_report_event(
+        db,
+        user_id=current_user.id,
+        report_scope="daily",
+        report_format="csv",
+        report_date=target_date.date(),
+        triggered_by="user_download",
+    )
+
     return Response(content=csv_content, media_type="text/csv; charset=utf-8", headers=headers)
 
 
@@ -1341,6 +1352,15 @@ def download_weekly_report(
     headers = {
         "Content-Disposition": f'attachment; filename="{filename}"'
     }
+
+    log_report_event(
+        db,
+        user_id=current_user.id,
+        report_scope="weekly",
+        report_format="csv",
+        report_date=start_date.date(),
+        triggered_by="user_download",
+    )
 
     return Response(content=csv_content, media_type="text/csv; charset=utf-8", headers=headers)
 
@@ -1373,6 +1393,15 @@ def download_daily_pdf(
         "Content-Disposition": f'attachment; filename="{filename}"'
     }
 
+    log_report_event(
+        db,
+        user_id=current_user.id,
+        report_scope="daily",
+        report_format="pdf",
+        report_date=target_date.date(),
+        triggered_by="user_download",
+    )
+
     return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)
 
 
@@ -1403,6 +1432,15 @@ def download_weekly_pdf(
     headers = {
         "Content-Disposition": f'attachment; filename="{filename}"'
     }
+
+    log_report_event(
+        db,
+        user_id=current_user.id,
+        report_scope="weekly",
+        report_format="pdf",
+        report_date=start_date.date(),
+        triggered_by="user_download",
+    )
 
     return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)
 
@@ -1743,6 +1781,7 @@ def profile_form(
             "user": current_user,
             "timezone_options": _timezone_options(current_user.timezone or "UTC"),
             "selected_timezone": current_user.timezone or "UTC",
+            "email_reports_supported": settings.EMAIL_SENDING_ENABLED,
         },
     )
 
@@ -1755,6 +1794,7 @@ def profile_update(
     first_name: str = Form(""),
     last_name: str = Form(""),
     timezone_name: str = Form(""),
+    wants_report_emails: Optional[bool] = Form(None),
     current_password: Optional[str] = Form(None),
     new_password: Optional[str] = Form(None),
     new_password_confirm: Optional[str] = Form(None),
@@ -1774,6 +1814,11 @@ def profile_update(
         current_user.timezone = _coerce_timezone(
             timezone_name or (current_user.timezone or "UTC")
         )
+
+        if settings.EMAIL_SENDING_ENABLED:
+            current_user.wants_report_emails = bool(wants_report_emails)
+        else:
+            current_user.wants_report_emails = False
 
         db.commit()
         db.refresh(current_user)
@@ -1822,6 +1867,7 @@ def profile_update(
         "user": current_user,
         "timezone_options": _timezone_options(current_user.timezone or "UTC"),
         "selected_timezone": current_user.timezone or "UTC",
+        "email_reports_supported": settings.EMAIL_SENDING_ENABLED,
         "profile_message": profile_message,
         "profile_error": profile_error,
         "password_message": password_message,

--- a/app/scripts/deliver_reports.py
+++ b/app/scripts/deliver_reports.py
@@ -1,0 +1,17 @@
+"""Cron-friendly entrypoint for scheduled report delivery."""
+from app.database import SessionLocal, engine
+from app.db_models import Base
+from app.services.report_delivery import deliver_daily_reports
+
+
+def main():
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+    try:
+        deliver_daily_reports(db=session)
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -1,0 +1,31 @@
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.db_models import ReportAudit
+
+
+def log_report_event(
+    db: Session,
+    *,
+    user_id: int,
+    report_scope: str,
+    report_format: str,
+    report_date: date,
+    triggered_by: str,
+    details: Optional[str] = None,
+) -> ReportAudit:
+    entry = ReportAudit(
+        user_id=user_id,
+        report_scope=report_scope,
+        report_format=report_format,
+        report_date=report_date,
+        triggered_by=triggered_by,
+        details=details,
+        created_at=datetime.utcnow(),
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry

--- a/app/services/email_client.py
+++ b/app/services/email_client.py
@@ -1,0 +1,42 @@
+from email.message import EmailMessage
+from typing import Iterable, Tuple
+import smtplib
+
+from app.config import settings
+
+Attachment = Tuple[str, bytes, str]
+
+
+def send_email(
+    *,
+    to_address: str,
+    subject: str,
+    body: str,
+    attachments: Iterable[Attachment] | None = None,
+):
+    if not settings.EMAIL_SENDING_ENABLED:
+        raise RuntimeError("Email sending is disabled.")
+
+    if not settings.EMAIL_SMTP_HOST:
+        raise RuntimeError("SMTP host is not configured.")
+
+    msg = EmailMessage()
+    msg["From"] = settings.EMAIL_FROM_ADDRESS
+    msg["To"] = to_address
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    for attachment in attachments or []:
+        name, content, mime_type = attachment
+        if isinstance(content, str):
+            content_bytes = content.encode("utf-8")
+        else:
+            content_bytes = content
+        maintype, subtype = mime_type.split("/", 1)
+        msg.add_attachment(content_bytes, maintype=maintype, subtype=subtype, filename=name)
+
+    with smtplib.SMTP(settings.EMAIL_SMTP_HOST, settings.EMAIL_SMTP_PORT) as smtp:
+        smtp.starttls()
+        if settings.EMAIL_SMTP_USERNAME and settings.EMAIL_SMTP_PASSWORD:
+            smtp.login(settings.EMAIL_SMTP_USERNAME, settings.EMAIL_SMTP_PASSWORD)
+        smtp.send_message(msg)

--- a/app/services/report_delivery.py
+++ b/app/services/report_delivery.py
@@ -1,0 +1,151 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.database import SessionLocal
+from app.db_models import ReportAudit, User
+from app.services.audit import log_report_event
+from app.services.email_client import send_email
+from app.services.report_exports import daily_report_to_csv, daily_report_to_pdf
+from app.services.reporting import build_daily_report
+
+logger = logging.getLogger(__name__)
+
+
+def _user_display_name(user: User) -> str:
+    name = f"{(user.first_name or '').strip()} {(user.last_name or '').strip()}".strip()
+    return name or user.email
+
+
+def _get_tz(user: User) -> ZoneInfo:
+    try:
+        return ZoneInfo(user.timezone or "UTC")
+    except Exception:
+        return ZoneInfo("UTC")
+
+
+def _should_send_now(now_local: datetime) -> bool:
+    local_midnight = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    seconds_since_midnight = (now_local - local_midnight).total_seconds()
+    return 0 <= seconds_since_midnight < 3600
+
+
+def _report_date_for_window(now_local: datetime) -> datetime:
+    midnight = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    return midnight - timedelta(days=1)
+
+
+def deliver_daily_reports(
+    *,
+    now_utc: Optional[datetime] = None,
+    db: Optional[Session] = None,
+) -> List[str]:
+    if not settings.EMAIL_SENDING_ENABLED:
+        logger.info("Email sending disabled; skipping scheduled reports.")
+        return []
+
+    owns_session = False
+    session = db
+    if session is None:
+        session = SessionLocal()
+        owns_session = True
+
+    delivered: List[str] = []
+    now_utc = now_utc or datetime.now(timezone.utc)
+
+    try:
+        users = (
+            session.query(User)
+            .filter(User.is_active.is_(True), User.wants_report_emails.is_(True))
+            .all()
+        )
+
+        for user in users:
+            tz = _get_tz(user)
+            now_local = now_utc.astimezone(tz)
+            if not _should_send_now(now_local):
+                continue
+
+            report_local_date = _report_date_for_window(now_local)
+            already_sent = (
+                session.query(ReportAudit)
+                .filter(
+                    ReportAudit.user_id == user.id,
+                    ReportAudit.report_scope == "daily",
+                    ReportAudit.report_format == "email",
+                    ReportAudit.report_date == report_local_date.date(),
+                )
+                .first()
+            )
+            if already_sent:
+                continue
+
+            report = build_daily_report(
+                session,
+                user.id,
+                datetime(
+                    report_local_date.year,
+                    report_local_date.month,
+                    report_local_date.day,
+                    tzinfo=tz,
+                ),
+            )
+
+            csv_content = daily_report_to_csv(report)
+            pdf_content = daily_report_to_pdf(
+                report,
+                user_name=_user_display_name(user),
+                user_timezone=user.timezone or "UTC",
+            )
+
+            subject = f"Your daily report for {report_local_date.date().isoformat()}"
+            body = "Attached is your daily RaterHub report."
+
+            try:
+                send_email(
+                    to_address=user.email,
+                    subject=subject,
+                    body=body,
+                    attachments=[
+                        (
+                            f"daily_report_{report_local_date.date().isoformat()}.csv",
+                            csv_content,
+                            "text/csv",
+                        ),
+                        (
+                            f"daily_report_{report_local_date.date().isoformat()}.pdf",
+                            pdf_content,
+                            "application/pdf",
+                        ),
+                    ],
+                )
+                log_report_event(
+                    session,
+                    user_id=user.id,
+                    report_scope="daily",
+                    report_format="email",
+                    report_date=report_local_date.date(),
+                    triggered_by="scheduler",
+                    details="sent",
+                )
+                delivered.append(user.email)
+            except Exception as exc:  # pragma: no cover - network errors are environment-specific
+                logger.exception("Failed to deliver report email for %s", user.email)
+                log_report_event(
+                    session,
+                    user_id=user.id,
+                    report_scope="daily",
+                    report_format="email",
+                    report_date=report_local_date.date(),
+                    triggered_by="scheduler",
+                    details=f"failed: {exc}",
+                )
+
+        return delivered
+    finally:
+        if owns_session:
+            session.close()

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -40,6 +40,18 @@
         color: var(--accent-dark);
     }
 
+    .switch-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .switch-row input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--accent);
+    }
+
     .input, select {
         width: 100%;
         padding: 9px 10px;
@@ -190,6 +202,26 @@
                     {% endfor %}
                 </select>
                 <div class="hint">Pick the timezone used when showing your session times.</div>
+            </div>
+
+            <div class="form-field">
+                <label for="wants_report_emails">Report emails</label>
+                <div class="switch-row">
+                    <input
+                        type="checkbox"
+                        id="wants_report_emails"
+                        name="wants_report_emails"
+                        value="1"
+                        {% if user.wants_report_emails %}checked{% endif %}
+                        {% if not email_reports_supported %}disabled{% endif %}
+                    >
+                    <span>Send me daily summaries at midnight</span>
+                </div>
+                {% if email_reports_supported %}
+                <div class="hint">We will email you the previous day's report at the start of your local day.</div>
+                {% else %}
+                <div class="hint">Email delivery is disabled on this deployment.</div>
+                {% endif %}
             </div>
 
             <div class="actions">

--- a/app/templates/today.html
+++ b/app/templates/today.html
@@ -103,6 +103,47 @@
             margin-bottom: 18px;
         }
 
+        .download-card {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .download-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+
+        .download-actions {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        .download-button {
+            padding: 8px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--border-subtle);
+            background: linear-gradient(180deg, #fff, #f5f1ff);
+            color: var(--accent-dark);
+            font-weight: 700;
+            cursor: pointer;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.04);
+        }
+
+        .download-button:hover {
+            border-color: var(--accent);
+            color: var(--accent);
+        }
+
+        .download-hint {
+            font-size: 12px;
+            color: var(--text-muted);
+        }
+
         .summary-label {
             font-size: 12px;
             text-transform: uppercase;
@@ -386,6 +427,7 @@
             <input
                 type="date"
                 name="date"
+                id="date-picker"
                 value="{{ selected_date if selected_date else (summary.date.strftime('%Y-%m-%d') if summary.date else '') }}"
                 style="padding: 4px 6px; border-radius: 6px; border: 1px solid #ccc; font-size: 13px;"
             >
@@ -409,6 +451,29 @@
         </button>
     </form>
     <p class="subtitle" style="margin-top: 0;">Times shown in {{ user_timezone or 'UTC' }}.</p>
+
+    <div class="wide-card download-card">
+        <div class="download-row">
+            <div>
+                <div class="summary-label">Daily report</div>
+                <div class="download-hint">Exports the selected day: <span id="daily-date-label"></span></div>
+            </div>
+            <div class="download-actions">
+                <button type="button" class="download-button" onclick="downloadReport('daily', 'csv')">Download CSV</button>
+                <button type="button" class="download-button" onclick="downloadReport('daily', 'pdf')">Download PDF</button>
+            </div>
+        </div>
+        <div class="download-row">
+            <div>
+                <div class="summary-label">Weekly report</div>
+                <div class="download-hint">Week of <span id="weekly-range-label"></span> (Mon–Sun)</div>
+            </div>
+            <div class="download-actions">
+                <button type="button" class="download-button" onclick="downloadReport('weekly', 'csv')">Download CSV</button>
+                <button type="button" class="download-button" onclick="downloadReport('weekly', 'pdf')">Download PDF</button>
+            </div>
+        </div>
+    </div>
 
     <!-- Top summary cards -->
     <div class="summary-grid">
@@ -497,7 +562,7 @@
             No activity recorded yet today. Once you start rating tasks, your sessions will show up here.
         </div>
     {% else %}
-        <div class="sessions-list">
+<div class="sessions-list">
             {% for s in summary.sessions %}
                 <div class="session-card">
                     <div class="session-header">
@@ -571,6 +636,77 @@
 </div>
 
 <script>
+    const dateInput = document.getElementById('date-picker');
+    const fallbackDate = "{{ selected_date if selected_date else (summary.date.strftime('%Y-%m-%d') if summary.date else '') }}";
+
+    function getSelectedDateIso() {
+        return (dateInput && dateInput.value) || fallbackDate || '';
+    }
+
+    function computeWeekStart(dateIso) {
+        const [year, month, day] = dateIso.split('-').map((value) => Number.parseInt(value, 10));
+        if (!year || !month || !day) return '';
+        const date = new Date(Date.UTC(year, month - 1, day));
+        const weekday = date.getUTCDay();
+        const daysSinceMonday = (weekday + 6) % 7;
+        date.setUTCDate(date.getUTCDate() - daysSinceMonday);
+        return date.toISOString().slice(0, 10);
+    }
+
+    function computeWeekRange(dateIso) {
+        const startIso = computeWeekStart(dateIso);
+        if (!startIso) return { start: '', end: '' };
+        const [year, month, day] = startIso.split('-').map((value) => Number.parseInt(value, 10));
+        const endDate = new Date(Date.UTC(year, month - 1, day));
+        endDate.setUTCDate(endDate.getUTCDate() + 6);
+        const endIso = endDate.toISOString().slice(0, 10);
+        return { start: startIso, end: endIso };
+    }
+
+    function updateReportLabels() {
+        const dateIso = getSelectedDateIso();
+        const dailyLabel = document.getElementById('daily-date-label');
+        const weeklyLabel = document.getElementById('weekly-range-label');
+
+        if (dailyLabel) {
+            dailyLabel.textContent = dateIso || 'select a date first';
+        }
+
+        if (weeklyLabel) {
+            const range = computeWeekRange(dateIso);
+            weeklyLabel.textContent = range.start && range.end ? `${range.start} – ${range.end}` : 'select a date first';
+        }
+    }
+
+    function downloadReport(scope, format) {
+        const dateIso = getSelectedDateIso();
+        if (!dateIso) {
+            alert('Pick a date to export your reports.');
+            return;
+        }
+
+        const params = new URLSearchParams();
+        if (scope === 'daily') {
+            params.set('date', dateIso);
+        } else {
+            const weekStart = computeWeekStart(dateIso);
+            if (!weekStart) {
+                alert('Could not determine the start of that week.');
+                return;
+            }
+            params.set('week_start', weekStart);
+        }
+
+        window.location.href = `/reports/${scope}.${format}?${params.toString()}`;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (dateInput) {
+            dateInput.addEventListener('change', updateReportLabels);
+        }
+        updateReportLabels();
+    });
+
     (function() {
         const tooltip = document.getElementById('sparkline-tooltip');
         const axis = document.getElementById('sparkline-axis');

--- a/scripts/add_report_email_tables.py
+++ b/scripts/add_report_email_tables.py
@@ -1,0 +1,86 @@
+"""Ensure email-related tables/columns exist for scheduled reports.
+
+This lightweight migration script is intended for production deployments.
+It safely creates the `report_audit_logs` table (added for email delivery
+tracking) and adds the supporting user columns when missing. The script is
+idempotent and can be re-run.
+
+Usage (from repo root):
+    SECRET_KEY=... DATABASE_URL=... python scripts/add_report_email_tables.py
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import NoSuchTableError
+
+from app.database import engine
+from app.db_models import ReportAudit
+
+
+def _table_exists(engine: Engine, table: str) -> bool:
+    inspector = inspect(engine)
+    return inspector.has_table(table)
+
+
+def _has_column(engine: Engine, table: str, column: str) -> bool:
+    inspector = inspect(engine)
+    try:
+        columns: Iterable[dict] = inspector.get_columns(table)
+    except NoSuchTableError:
+        return False
+
+    return any(col.get("name") == column for col in columns)
+
+
+def _create_report_audit_logs(engine: Engine) -> bool:
+    if _table_exists(engine, "report_audit_logs"):
+        print("Table report_audit_logs already exists. Skipping creation.")
+        return False
+
+    print("Creating table: report_audit_logs")
+    ReportAudit.__table__.create(bind=engine, checkfirst=True)
+    return True
+
+
+def _ensure_user_columns(engine: Engine) -> list[str]:
+    added: list[str] = []
+    for column_name, ddl_sqlite, ddl_postgres in (
+        (
+            "timezone",
+            "ALTER TABLE users ADD COLUMN timezone VARCHAR(255) DEFAULT 'UTC' NOT NULL;",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone VARCHAR(255) DEFAULT 'UTC' NOT NULL;",
+        ),
+        (
+            "wants_report_emails",
+            "ALTER TABLE users ADD COLUMN wants_report_emails BOOLEAN DEFAULT 0 NOT NULL;",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS wants_report_emails BOOLEAN DEFAULT FALSE NOT NULL;",
+        ),
+    ):
+        if _has_column(engine, "users", column_name):
+            continue
+
+        print(f"Adding column to users: {column_name}")
+        dialect = engine.dialect.name
+        ddl = text(ddl_postgres if dialect == "postgresql" else ddl_sqlite)
+        with engine.begin() as conn:
+            conn.execute(ddl)
+        added.append(column_name)
+
+    return added
+
+
+if __name__ == "__main__":
+    created_table = _create_report_audit_logs(engine)
+    added_columns = _ensure_user_columns(engine)
+
+    if created_table or added_columns:
+        print("Migration complete. Changes applied:")
+        if created_table:
+            print("  - report_audit_logs table created")
+        for column in added_columns:
+            print(f"  - users.{column} column added")
+    else:
+        print("Nothing to do; email-related tables/columns already present.")


### PR DESCRIPTION
## Summary
- add a production-safe migration script to create the report_audit_logs table and supporting email preference columns if missing
- document how to run the migration for upgrades

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ba54f60a8832e81f6685fb7394635)