### PR TITLE
Add admin console user management and diagnostics

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -417,6 +417,12 @@ def require_admin(current_user: User = Depends(get_current_user)) -> User:
         raise HTTPException(status_code=403, detail="Admin privileges required")
     return current_user
 
+
+def _parse_bool(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return str(value).lower() in {"1", "true", "yes", "on"}
+
 # ============================================================
 # Root & health
 # ============================================================
@@ -1659,6 +1665,41 @@ def delete_question_web(
 # Admin debug endpoints + HTML dashboard
 # ============================================================
 
+
+def _admin_dashboard_context(
+    db: OrmSession,
+    *,
+    target_user_id: Optional[int],
+    flash_message: Optional[str] = None,
+    flash_error: Optional[str] = None,
+):
+    users = db.query(User).order_by(User.created_at.desc()).all()
+
+    target_user = None
+    if target_user_id is not None:
+        target_user = next((u for u in users if u.id == target_user_id), None)
+
+    if target_user is None and users:
+        target_user = users[0]
+
+    sessions: list[DbSession] = []
+    if target_user:
+        sessions = (
+            db.query(DbSession)
+            .filter(DbSession.user_id == target_user.id)
+            .order_by(DbSession.started_at.desc())
+            .limit(20)
+            .all()
+        )
+
+    return {
+        "users": users,
+        "target_user": target_user,
+        "sessions": sessions,
+        "flash_message": flash_message,
+        "flash_error": flash_error,
+    }
+
 @app.get("/admin/debug/user-sessions")
 def debug_user_sessions(
     user_id: Optional[int] = Query(None),
@@ -1730,6 +1771,172 @@ def debug_user_events(
     ]
 
 
+@app.get("/admin/users")
+def list_users_admin(current_user: User = Depends(require_admin), db: OrmSession = Depends(get_db)):
+    users = db.query(User).order_by(User.created_at.desc()).all()
+    return [
+        {
+            "id": user.id,
+            "email": user.email,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "role": user.role,
+            "is_active": user.is_active,
+            "created_at": user.created_at,
+            "last_login_at": user.last_login_at,
+        }
+        for user in users
+    ]
+
+
+@app.post("/admin/users/manage", response_class=HTMLResponse)
+def manage_users_admin(
+    request: Request,
+    form_type: str = Form(...),
+    csrf_token: Optional[str] = Form(None),
+    view_user_id: Optional[int] = Form(None),
+    user_id: Optional[int] = Form(None),
+    email: str = Form(""),
+    first_name: str = Form(""),
+    last_name: str = Form(""),
+    password: str = Form(""),
+    password_confirm: str = Form(""),
+    role: str = Form("user"),
+    is_active: Optional[str] = Form(None),
+    new_password: str = Form(""),
+    new_password_confirm: str = Form(""),
+    confirm_email: str = Form(""),
+    current_user: User = Depends(require_admin),
+    db: OrmSession = Depends(get_db),
+):
+    flash_message = None
+    flash_error = None
+    status_code = 200
+    target_user_id = view_user_id
+
+    if not validate_csrf(request, csrf_token):
+        flash_error = "Invalid or missing CSRF token."
+        status_code = 400
+    elif form_type == "create":
+        normalized_email = email.strip().lower()
+
+        if not normalized_email or "@" not in normalized_email:
+            flash_error = "Please provide a valid email."
+        elif password != password_confirm:
+            flash_error = "Passwords do not match."
+        elif db.query(User).filter(User.email == normalized_email).first():
+            flash_error = "Email is already registered."
+        else:
+            is_valid, policy_error = validate_password_policy(password)
+            if not is_valid:
+                flash_error = policy_error
+            else:
+                now = datetime.utcnow()
+                sanitized_role = role if role in {"admin", "user"} else "user"
+                active_flag = _parse_bool(is_active) if is_active is not None else True
+                new_user = User(
+                    external_id=normalized_email,
+                    email=normalized_email,
+                    first_name=first_name.strip(),
+                    last_name=last_name.strip(),
+                    created_at=now,
+                    last_login_at=None,
+                    password_hash=get_password_hash(password),
+                    auth_provider="local",
+                    is_active=active_flag,
+                    role=sanitized_role,
+                    timezone="UTC",
+                )
+                db.add(new_user)
+                db.commit()
+                db.refresh(new_user)
+                db.add(PasswordHistory(user_id=new_user.id, password_hash=new_user.password_hash))
+                db.commit()
+
+                flash_message = "User account created."
+                target_user_id = new_user.id
+
+    elif form_type == "activation":
+        if user_id is None:
+            flash_error = "User selection is required."
+        else:
+            user = db.query(User).filter(User.id == user_id).first()
+            if not user:
+                flash_error = "User not found."
+            elif user.id == current_user.id:
+                flash_error = "You cannot change your own activation from this page."
+            else:
+                user.is_active = _parse_bool(is_active)
+                db.commit()
+                flash_message = "User activation status updated."
+                target_user_id = user.id
+
+    elif form_type == "reset_password":
+        if user_id is None:
+            flash_error = "User selection is required."
+        elif new_password != new_password_confirm:
+            flash_error = "New passwords do not match."
+        else:
+            user = db.query(User).filter(User.id == user_id).first()
+            if not user:
+                flash_error = "User not found."
+            else:
+                recent_history = (
+                    db.query(PasswordHistory)
+                    .filter(PasswordHistory.user_id == user.id)
+                    .order_by(PasswordHistory.created_at.desc())
+                    .limit(5)
+                    .all()
+                )
+                recent_hashes = [p.password_hash for p in recent_history]
+                is_valid, policy_error = validate_password_policy(
+                    new_password, recent_hashes
+                )
+
+                if not is_valid:
+                    flash_error = policy_error
+                else:
+                    new_hash = get_password_hash(new_password)
+                    user.password_hash = new_hash
+                    db.add(PasswordHistory(user_id=user.id, password_hash=new_hash))
+                    db.commit()
+                    flash_message = "Password reset successfully."
+                    target_user_id = user.id
+
+    elif form_type == "delete":
+        if user_id is None:
+            flash_error = "User selection is required."
+        else:
+            user = db.query(User).filter(User.id == user_id).first()
+            if not user:
+                flash_error = "User not found."
+            elif confirm_email.strip().lower() != user.email.lower():
+                flash_error = "Confirmation email does not match."
+            elif user.id == current_user.id:
+                flash_error = "You cannot delete your own account from the admin console."
+            else:
+                db.delete(user)
+                db.commit()
+                flash_message = "User deleted."
+                target_user_id = None
+    else:
+        flash_error = "Unknown admin action."
+
+    if flash_error:
+        status_code = 400
+
+    context = _admin_dashboard_context(
+        db,
+        target_user_id=target_user_id,
+        flash_message=flash_message,
+        flash_error=flash_error,
+    )
+    context["user"] = current_user
+    response = render_template_with_csrf("admin_dashboard.html", request, context)
+    response.status_code = status_code
+    return response
+
+
 @app.get("/admin/dashboard", response_class=HTMLResponse)
 def admin_dashboard(
     request: Request,
@@ -1738,27 +1945,167 @@ def admin_dashboard(
     db: OrmSession = Depends(get_db),
 ):
     target_user_id = user_id if user_id is not None else current_user.id
-    target_user = db.query(User).filter(User.id == target_user_id).first()
-    if not target_user:
+    context = _admin_dashboard_context(db, target_user_id=target_user_id)
+    context["user"] = current_user
+    return render_template_with_csrf("admin_dashboard.html", request, context)
+
+
+def _get_admin_report_user(
+    db: OrmSession, requested_user_id: Optional[int], current_user: User
+) -> User:
+    target_user_id = requested_user_id if requested_user_id is not None else current_user.id
+    user = db.query(User).filter(User.id == target_user_id).first()
+    if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    return user
 
-    sessions = (
-        db.query(DbSession)
-        .filter(DbSession.user_id == target_user_id)
-        .order_by(DbSession.started_at.desc())
-        .limit(20)
-        .all()
+
+@app.get("/admin/reports/daily.csv")
+def admin_download_daily_report(
+    date: str = Query(..., description="Date in YYYY-MM-DD (user timezone)"),
+    user_id: Optional[int] = Query(None),
+    current_user: User = Depends(require_admin),
+    db: OrmSession = Depends(get_db),
+):
+    try:
+        target_date = datetime.strptime(date, "%Y-%m-%d")
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format, use YYYY-MM-DD")
+
+    from app.services.report_exports import daily_report_to_csv
+    from app.services.reporting import build_daily_report
+
+    target_user = _get_admin_report_user(db, user_id, current_user)
+    report = build_daily_report(db, target_user.id, target_date)
+    csv_content = daily_report_to_csv(report)
+
+    filename = f"daily_report_{target_date.date().isoformat()}_{target_user.id}.csv"
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+
+    log_report_event(
+        db,
+        user_id=target_user.id,
+        report_scope="daily",
+        report_format="csv",
+        report_date=target_date.date(),
+        triggered_by="admin_download",
+        details=f"requested_by={current_user.email}",
     )
 
-    return templates.TemplateResponse(
-        "admin_dashboard.html",
-        {
-            "request": request,
-            "sessions": sessions,
-            "user": current_user,
-            "target_user": target_user,
-        },
+    return Response(content=csv_content, media_type="text/csv; charset=utf-8", headers=headers)
+
+
+@app.get("/admin/reports/weekly.csv")
+def admin_download_weekly_report(
+    week_start: str = Query(..., description="Week start in YYYY-MM-DD (user timezone)"),
+    user_id: Optional[int] = Query(None),
+    current_user: User = Depends(require_admin),
+    db: OrmSession = Depends(get_db),
+):
+    try:
+        start_date = datetime.strptime(week_start, "%Y-%m-%d")
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format, use YYYY-MM-DD")
+
+    from app.services.report_exports import weekly_report_to_csv
+    from app.services.reporting import build_weekly_report
+
+    target_user = _get_admin_report_user(db, user_id, current_user)
+    report = build_weekly_report(db, target_user.id, start_date)
+    csv_content = weekly_report_to_csv(report)
+
+    filename = f"weekly_report_{start_date.date().isoformat()}_{target_user.id}.csv"
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+
+    log_report_event(
+        db,
+        user_id=target_user.id,
+        report_scope="weekly",
+        report_format="csv",
+        report_date=start_date.date(),
+        triggered_by="admin_download",
+        details=f"requested_by={current_user.email}",
     )
+
+    return Response(content=csv_content, media_type="text/csv; charset=utf-8", headers=headers)
+
+
+@app.get("/admin/reports/daily.pdf")
+def admin_download_daily_pdf(
+    date: str = Query(..., description="Date in YYYY-MM-DD (user timezone)"),
+    user_id: Optional[int] = Query(None),
+    current_user: User = Depends(require_admin),
+    db: OrmSession = Depends(get_db),
+):
+    try:
+        target_date = datetime.strptime(date, "%Y-%m-%d")
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format, use YYYY-MM-DD")
+
+    from app.services.reporting import build_daily_report
+    from app.services.report_exports import daily_report_to_pdf
+
+    target_user = _get_admin_report_user(db, user_id, current_user)
+    report = build_daily_report(db, target_user.id, target_date)
+    pdf_bytes = daily_report_to_pdf(
+        report,
+        user_name=get_user_display_name(target_user),
+        user_timezone=getattr(target_user, "timezone", "UTC"),
+    )
+
+    filename = f"daily_report_{target_date.date().isoformat()}_{target_user.id}.pdf"
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+
+    log_report_event(
+        db,
+        user_id=target_user.id,
+        report_scope="daily",
+        report_format="pdf",
+        report_date=target_date.date(),
+        triggered_by="admin_download",
+        details=f"requested_by={current_user.email}",
+    )
+
+    return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)
+
+
+@app.get("/admin/reports/weekly.pdf")
+def admin_download_weekly_pdf(
+    week_start: str = Query(..., description="Week start in YYYY-MM-DD (user timezone)"),
+    user_id: Optional[int] = Query(None),
+    current_user: User = Depends(require_admin),
+    db: OrmSession = Depends(get_db),
+):
+    try:
+        start_date = datetime.strptime(week_start, "%Y-%m-%d")
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format, use YYYY-MM-DD")
+
+    from app.services.reporting import build_weekly_report
+    from app.services.report_exports import weekly_report_to_pdf
+
+    target_user = _get_admin_report_user(db, user_id, current_user)
+    report = build_weekly_report(db, target_user.id, start_date)
+    pdf_bytes = weekly_report_to_pdf(
+        report,
+        user_name=get_user_display_name(target_user),
+        user_timezone=getattr(target_user, "timezone", "UTC"),
+    )
+
+    filename = f"weekly_report_{start_date.date().isoformat()}_{target_user.id}.pdf"
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+
+    log_report_event(
+        db,
+        user_id=target_user.id,
+        report_scope="weekly",
+        report_format="pdf",
+        report_date=start_date.date(),
+        triggered_by="admin_download",
+        details=f"requested_by={current_user.email}",
+    )
+
+    return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)
 
 # ============================================================
 # Profile (timezone, etc.)

--- a/app/main.py
+++ b/app/main.py
@@ -412,8 +412,12 @@ def get_current_user(
     return user
 
 
+def is_admin_user(user: User) -> bool:
+    return getattr(user, "role", "user") == "admin"
+
+
 def require_admin(current_user: User = Depends(get_current_user)) -> User:
-    if getattr(current_user, "role", "user") != "admin":
+    if not is_admin_user(current_user):
         raise HTTPException(status_code=403, detail="Admin privileges required")
     return current_user
 
@@ -1070,6 +1074,7 @@ def dashboard_session(
             "request": request,
             "summary": summary,
             "current_user_email": getattr(current_user, "email", None),
+            "is_admin": is_admin_user(current_user),
         },
     )
 
@@ -1298,6 +1303,7 @@ def dashboard_today(
             "selected_date": selected_date_str,
             "user_timezone": getattr(current_user, "timezone", None),
             "current_user_email": getattr(current_user, "email", None),
+            "is_admin": is_admin_user(current_user),
         },
     )
 
@@ -1330,6 +1336,7 @@ def dashboard_reports(
             "selected_date": selected_date_str,
             "user_timezone": getattr(current_user, "timezone", None),
             "current_user_email": getattr(current_user, "email", None),
+            "is_admin": is_admin_user(current_user),
         },
     )
 

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -1,127 +1,414 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Admin Debug Dashboard</title>
+{% extends "base.html" %}
+{% block title %}Admin Console – RaterHub Tracker{% endblock %}
 
-    <style>
-        body {
-            font-family: system-ui, sans-serif;
-            margin: 24px;
-            background: #faf8ff;
-        }
+{% block content %}
+<style>
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 16px;
+    }
 
-        h1 {
-            color: #4b3b86;
-            margin-bottom: 6px;
-        }
+    .page-header a {
+        color: var(--accent);
+        font-size: 13px;
+        text-decoration: none;
+        font-weight: 600;
+    }
 
-        .subtitle {
-            color: #666;
-            margin-bottom: 20px;
-        }
+    .page-header a:hover {
+        color: var(--accent-dark);
+        text-decoration: underline;
+    }
 
-        table {
-            border-collapse: collapse;
-            width: 420px;
-            margin-bottom: 30px;
-            background: #fff;
-            border-radius: 10px;
-            overflow: hidden;
-            box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-        }
+    .grid {
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: 16px;
+    }
 
-        th, td {
-            padding: 10px 14px;
-            border-bottom: 1px solid #eee;
-        }
+    .full-width {
+        grid-column: 1 / -1;
+    }
 
-        th {
-            background: #f0eaff;
-            text-align: left;
-        }
+    .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 10px;
+    }
 
-        tr:hover {
-            background: #f7f3ff;
-            cursor: pointer;
-        }
+    .hint {
+        font-size: 12px;
+        color: var(--text-muted);
+    }
 
-        #events-box {
-            background: #fff;
-            padding: 16px;
-            border-radius: 10px;
-            width: 600px;
-            max-height: 600px;
-            overflow-y: auto;
-            box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-        }
+    .form-field {
+        margin-bottom: 10px;
+    }
 
-        pre {
-            white-space: pre-wrap;
-            font-size: 13px;
-            line-height: 1.3em;
-        }
-    </style>
-</head>
+    .form-field label {
+        display: block;
+        font-size: 13px;
+        margin-bottom: 6px;
+        font-weight: 600;
+        color: var(--accent-dark);
+    }
 
-<body>
+    .input, select {
+        width: 100%;
+        padding: 9px 10px;
+        border-radius: 10px;
+        border: 1px solid var(--border-subtle);
+        font-size: 14px;
+        box-sizing: border-box;
+        background: #fff;
+    }
 
-<h1>Admin Debug Dashboard</h1>
-<div class="subtitle">Welcome, {{ user.email }} — click a session to view raw events.</div>
+    .input-inline {
+        display: inline-block;
+        width: auto;
+        min-width: 180px;
+    }
 
-<h2>Recent Sessions</h2>
+    .actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 6px;
+    }
 
-<table>
-    <tr>
-        <th>Session ID</th>
-        <th>Started</th>
-        <th>Ended</th>
-    </tr>
+    .btn {
+        border: none;
+        border-radius: 10px;
+        padding: 9px 12px;
+        font-weight: 700;
+        cursor: pointer;
+        font-size: 13px;
+    }
 
-    {% for s in sessions %}
-    <tr onclick="loadEvents('{{ s.public_id }}')">
-        <td>{{ s.public_id }}</td>
-        <td>{{ s.started_at }}</td>
-        <td>{{ s.ended_at }}</td>
-    </tr>
-    {% endfor %}
-</table>
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: var(--accent-dark); }
+    .btn-secondary { background: #f5f1ff; color: var(--accent-dark); border: 1px solid var(--border-subtle); }
+    .btn-danger { background: #fee2e2; color: #991b1b; border: 1px solid #fecdd3; }
 
-<h2>Session Event Log</h2>
-<div id="events-box">
-    <pre id="events-output">Select a session above to view events.</pre>
+    .alert {
+        border-radius: 12px;
+        padding: 10px 12px;
+        font-size: 13px;
+        margin-bottom: 12px;
+    }
+    .alert-success { background: #ecfdf3; color: #166534; border: 1px solid #bbf7d0; }
+    .alert-error { background: #fef2f2; color: #b91c1c; border: 1px solid #fecdd3; }
+
+    table { margin-top: 6px; }
+    th, td { font-size: 12px; }
+
+    .pill-admin { background: #ffe8cc; color: #9a3412; }
+    .pill-user { background: var(--accent-light); color: var(--accent-dark); }
+
+    .event-log {
+        background: var(--card-bg);
+        border: 1px solid var(--border-subtle);
+        border-radius: 12px;
+        padding: 12px;
+        min-height: 160px;
+        white-space: pre-wrap;
+        font-size: 12px;
+        color: var(--text-main);
+    }
+
+    .stacked-forms form { margin-bottom: 12px; }
+</style>
+
+<div class="page-header">
+    <div>
+        <h1>Admin console</h1>
+        <div class="subtitle">Manage accounts, audit sessions, and trigger reports. Signed in as {{ user.email }}.</div>
+    </div>
+    <div>
+        <a href="/dashboard/today">← Back to dashboard</a>
+    </div>
+</div>
+
+{% if flash_message %}
+    <div class="alert alert-success">{{ flash_message }}</div>
+{% endif %}
+{% if flash_error %}
+    <div class="alert alert-error">{{ flash_error }}</div>
+{% endif %}
+
+<div class="grid">
+    <div class="card">
+        <div class="section-header">
+            <h2>Create a new user</h2>
+            <span class="hint">Passwords must meet policy requirements.</span>
+        </div>
+        <form method="post" action="/admin/users/manage">
+            <input type="hidden" name="form_type" value="create">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <input type="hidden" name="view_user_id" value="{{ target_user.id if target_user else '' }}">
+
+            <div class="form-field">
+                <label for="new_email">Email</label>
+                <input class="input" id="new_email" name="email" type="email" required>
+            </div>
+            <div class="form-field">
+                <label for="new_first_name">First name</label>
+                <input class="input" id="new_first_name" name="first_name" type="text">
+            </div>
+            <div class="form-field">
+                <label for="new_last_name">Last name</label>
+                <input class="input" id="new_last_name" name="last_name" type="text">
+            </div>
+            <div class="form-field">
+                <label for="new_role">Role</label>
+                <select id="new_role" name="role">
+                    <option value="user">Standard user</option>
+                    <option value="admin">Admin</option>
+                </select>
+            </div>
+            <div class="form-field">
+                <label for="new_password">Password</label>
+                <input class="input" id="new_password" name="password" type="password" required>
+            </div>
+            <div class="form-field">
+                <label for="new_password_confirm">Confirm password</label>
+                <input class="input" id="new_password_confirm" name="password_confirm" type="password" required>
+            </div>
+            <div class="form-field">
+                <label for="new_is_active">Activation</label>
+                <select id="new_is_active" name="is_active">
+                    <option value="true" selected>Active</option>
+                    <option value="false">Inactive</option>
+                </select>
+            </div>
+            <div class="actions">
+                <button class="btn btn-primary" type="submit">Create account</button>
+            </div>
+        </form>
+    </div>
+
+    <div class="card">
+        <div class="section-header">
+            <h2>Account controls</h2>
+            <span class="hint">Select a user to manage their account.</span>
+        </div>
+
+        <form id="view-user-form" method="get" action="/admin/dashboard" class="form-field">
+            <label for="view_user_id">Focus user</label>
+            <select id="view_user_id" name="user_id" onchange="document.getElementById('view-user-form').submit()">
+                {% for u in users %}
+                    <option value="{{ u.id }}" {% if target_user and u.id == target_user.id %}selected{% endif %}>
+                        {{ u.email }} {% if u.role == 'admin' %}(admin){% endif %}
+                    </option>
+                {% endfor %}
+            </select>
+        </form>
+
+        {% if target_user %}
+        <div class="stacked-forms">
+            <form method="post" action="/admin/users/manage">
+                <input type="hidden" name="form_type" value="activation">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <input type="hidden" name="user_id" value="{{ target_user.id }}">
+                <input type="hidden" name="view_user_id" value="{{ target_user.id }}">
+                <input type="hidden" name="is_active" value="{% if target_user.is_active %}false{% else %}true{% endif %}">
+                <div class="actions">
+                    <div class="hint">Status: {% if target_user.is_active %}<span class="pill">Active</span>{% else %}<span class="pill">Inactive</span>{% endif %}</div>
+                    <button class="btn btn-secondary" type="submit">
+                        {% if target_user.is_active %}Deactivate{% else %}Activate{% endif %}
+                    </button>
+                </div>
+            </form>
+
+            <form method="post" action="/admin/users/manage">
+                <input type="hidden" name="form_type" value="reset_password">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <input type="hidden" name="user_id" value="{{ target_user.id }}">
+                <input type="hidden" name="view_user_id" value="{{ target_user.id }}">
+                <div class="form-field">
+                    <label for="reset_password">New password for {{ target_user.email }}</label>
+                    <input class="input" id="reset_password" name="new_password" type="password" required>
+                </div>
+                <div class="form-field">
+                    <label for="reset_password_confirm">Confirm new password</label>
+                    <input class="input" id="reset_password_confirm" name="new_password_confirm" type="password" required>
+                </div>
+                <div class="actions">
+                    <button class="btn btn-primary" type="submit">Reset password</button>
+                </div>
+            </form>
+
+            <form method="post" action="/admin/users/manage" onsubmit="return confirm('This will delete the user and their sessions. Continue?');">
+                <input type="hidden" name="form_type" value="delete">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <input type="hidden" name="user_id" value="{{ target_user.id }}">
+                <input type="hidden" name="view_user_id" value="{{ target_user.id }}">
+                <div class="form-field">
+                    <label for="confirm_email">Type {{ target_user.email }} to confirm deletion</label>
+                    <input class="input" id="confirm_email" name="confirm_email" type="text" required>
+                </div>
+                <div class="actions">
+                    <button class="btn btn-danger" type="submit">Delete account</button>
+                </div>
+            </form>
+        </div>
+        {% else %}
+            <div class="hint">No users available.</div>
+        {% endif %}
+    </div>
+
+    <div class="card full-width">
+        <div class="section-header">
+            <h2>User directory</h2>
+            <span class="hint">Recent accounts with status and roles.</span>
+        </div>
+        <table>
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Name</th>
+                    <th>Role</th>
+                    <th>Status</th>
+                    <th>Created</th>
+                    <th>Last login</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for u in users %}
+                    <tr {% if target_user and u.id == target_user.id %}style="background:#f3ecff"{% endif %}>
+                        <td>{{ u.email }}</td>
+                        <td>{{ (u.first_name or '') ~ ' ' ~ (u.last_name or '') }}</td>
+                        <td>
+                            <span class="pill {% if u.role == 'admin' %}pill-admin{% else %}pill-user{% endif %}">{{ u.role|capitalize }}</span>
+                        </td>
+                        <td>{% if u.is_active %}Active{% else %}Inactive{% endif %}</td>
+                        <td>{{ u.created_at }}</td>
+                        <td>{{ u.last_login_at or '—' }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="card full-width">
+        <div class="section-header">
+            <h2>Diagnostics</h2>
+            <span class="hint">Inspect sessions/events and trigger report exports for admins only.</span>
+        </div>
+
+        {% if target_user %}
+        <div class="grid" style="grid-template-columns: 1.1fr 1fr; gap: 12px;">
+            <div>
+                <h3>Recent sessions for {{ target_user.email }}</h3>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Session</th>
+                            <th>Started</th>
+                            <th>Ended</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for s in sessions %}
+                            <tr onclick="loadEvents('{{ s.public_id }}')" style="cursor:pointer;">
+                                <td>{{ s.public_id }}</td>
+                                <td>{{ s.started_at }}</td>
+                                <td>{{ s.ended_at or '—' }}</td>
+                            </tr>
+                        {% endfor %}
+                        {% if sessions|length == 0 %}
+                            <tr><td colspan="3">No sessions found.</td></tr>
+                        {% endif %}
+                    </tbody>
+                </table>
+            </div>
+            <div>
+                <h3>Event log</h3>
+                <div id="events-output" class="event-log">Select a session to view its events.</div>
+            </div>
+        </div>
+
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; margin-top: 12px;">
+            <div>
+                <h3>Report downloads</h3>
+                <form method="get" action="/admin/reports/daily.csv" class="form-field">
+                    <input type="hidden" name="user_id" value="{{ target_user.id }}">
+                    <label for="daily_date">Daily CSV date</label>
+                    <input class="input" id="daily_date" name="date" type="date" data-fill-today>
+                    <div class="actions">
+                        <button class="btn btn-secondary" type="submit">Download daily CSV</button>
+                    </div>
+                </form>
+                <form method="get" action="/admin/reports/weekly.csv" class="form-field">
+                    <input type="hidden" name="user_id" value="{{ target_user.id }}">
+                    <label for="weekly_start">Week start (CSV)</label>
+                    <input class="input" id="weekly_start" name="week_start" type="date" data-fill-today>
+                    <div class="actions">
+                        <button class="btn btn-secondary" type="submit">Download weekly CSV</button>
+                    </div>
+                </form>
+            </div>
+            <div>
+                <h3>PDF exports</h3>
+                <form method="get" action="/admin/reports/daily.pdf" class="form-field">
+                    <input type="hidden" name="user_id" value="{{ target_user.id }}">
+                    <label for="daily_pdf_date">Daily PDF date</label>
+                    <input class="input" id="daily_pdf_date" name="date" type="date" data-fill-today>
+                    <div class="actions">
+                        <button class="btn btn-secondary" type="submit">Download daily PDF</button>
+                    </div>
+                </form>
+                <form method="get" action="/admin/reports/weekly.pdf" class="form-field">
+                    <input type="hidden" name="user_id" value="{{ target_user.id }}">
+                    <label for="weekly_pdf_start">Week start (PDF)</label>
+                    <input class="input" id="weekly_pdf_start" name="week_start" type="date" data-fill-today>
+                    <div class="actions">
+                        <button class="btn btn-secondary" type="submit">Download weekly PDF</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        {% else %}
+            <div class="hint">No user selected for diagnostics.</div>
+        {% endif %}
+    </div>
 </div>
 
 <script>
-async function loadEvents(sessionId) {
-    const output = document.getElementById("events-output");
-    output.textContent = "Loading...";
+    const targetUserId = {{ target_user.id if target_user else 'null' }};
 
-    try {
-        const res = await fetch(`/admin/debug/user-events/${sessionId}`);
-        if (!res.ok) {
-            output.textContent = "Error loading events: " + res.statusText;
+    function loadEvents(sessionId) {
+        if (!targetUserId) {
             return;
         }
-
-        const data = await res.json();
-
-        if (!Array.isArray(data) || data.length === 0) {
-            output.textContent = "No events for this session.";
-            return;
-        }
-
-        let text = "";
-        for (const e of data) {
-            text += `[${e.timestamp}] ${e.type} (event #${e.id})\n`;
-        }
-
-        output.textContent = text;
-    } catch (err) {
-        output.textContent = "Fetch error: " + err;
+        const output = document.getElementById('events-output');
+        output.textContent = 'Loading...';
+        fetch(`/admin/debug/user-events/${sessionId}?user_id=${targetUserId}`)
+            .then(res => {
+                if (!res.ok) { throw new Error(res.statusText || 'Error'); }
+                return res.json();
+            })
+            .then(data => {
+                if (!Array.isArray(data) || data.length === 0) {
+                    output.textContent = 'No events for this session.';
+                    return;
+                }
+                const lines = data.map(e => `[${e.timestamp}] ${e.type} (event #${e.id})`);
+                output.textContent = lines.join('\n');
+            })
+            .catch(err => {
+                output.textContent = 'Error loading events: ' + err;
+            });
     }
-}
-</script>
 
-</body>
-</html>
+    document.querySelectorAll('[data-fill-today]').forEach((input) => {
+        if (!input.value) {
+            const today = new Date().toISOString().slice(0, 10);
+            input.value = today;
+        }
+    });
+</script>
+{% endblock %}

--- a/app/templates/reports_dashboard.html
+++ b/app/templates/reports_dashboard.html
@@ -160,7 +160,9 @@
         <span class="nav-user">Logged in as {{ current_user_email or 'Unknown user' }}</span>
         <a href="/dashboard/today">Today</a>
         <a href="/dashboard/reports">Reports</a>
+        {% if is_admin %}
         <a href="/admin/dashboard">Admin</a>
+        {% endif %}
         <a href="/profile">Preferences</a>
         <a href="/logout">Logout</a>
     </div>

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -303,8 +303,10 @@
         <span class="nav-user">Logged in as {{ current_user_email or 'Unknown user' }}</span>
         <a href="/dashboard/today">Today</a>
         <a href="/dashboard/reports">Reports</a>
+        {% if is_admin %}
         <a href="/admin/dashboard">Admin</a>
-                <a href="/profile">Preferences</a>
+        {% endif %}
+        <a href="/profile">Preferences</a>
         <a href="/logout">Logout</a>
     </div>
 </div>

--- a/app/templates/today.html
+++ b/app/templates/today.html
@@ -367,8 +367,10 @@
         <span class="nav-user">Logged in as {{ current_user_email or 'Unknown user' }}</span>
         <a href="/dashboard/today">Today</a>
         <a href="/dashboard/reports">Reports</a>
+        {% if is_admin %}
         <a href="/admin/dashboard">Admin</a>
-                <a href="/profile">Preferences</a>
+        {% endif %}
+        <a href="/profile">Preferences</a>
         <a href="/logout">Logout</a>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- redesign the admin dashboard to use the shared layout and surface user management, diagnostics, and report tools
- add admin-only handlers for user CRUD-style actions, CSRF validation, and report downloads scoped to selected users
- wire dashboard forms and fetch calls to the new endpoints with inline feedback

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb92a6520832e8244152e80221a3a)