### PR TITLE
Improve widget sizing and sign-in flow

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -87,7 +87,7 @@
   </head>
   <body>
     <h1>RaterHub Tracker</h1>
-    <div class="muted">Configure how the extension authenticates with the backend.</div>
+    <div class="muted">Configure how the extension authenticates with the backend. Saved credentials will be used to sign in automatically whenever the extension runs.</div>
 
     <div class="section">
       <label>Credential type</label>
@@ -126,8 +126,8 @@
       <div class="actions">
         <button id="save">Save credentials</button>
         <button id="request-refresh" class="secondary">Request refresh token</button>
-        <button id="login" class="secondary">Log in now</button>
-        <button id="test-login" class="secondary">Test login</button>
+        <button id="login" class="secondary">Sign in now</button>
+        <button id="reset-position" class="secondary">Reset widget position</button>
         <button id="logout" class="danger">Logout & reset</button>
       </div>
       <div id="status" class="status" style="display: none"></div>

--- a/extension/options.js
+++ b/extension/options.js
@@ -123,16 +123,6 @@ async function triggerLogin() {
   }
 }
 
-async function testLogin() {
-  showStatus("Testing login…");
-  const res = await chrome.runtime.sendMessage({ type: "LOGIN", silent: true });
-  if (res?.ok) {
-    showStatus("Login successful.", "success");
-  } else {
-    showStatus("Login failed.", "error");
-  }
-}
-
 async function logout() {
   showStatus("Clearing stored data…");
   await chrome.runtime.sendMessage({ type: "LOGOUT_RESET" });
@@ -145,6 +135,16 @@ async function logout() {
   showStatus("Credentials and tokens cleared.", "success");
 }
 
+async function clearWidgetPosition() {
+  showStatus("Resetting widget position…");
+  const res = await chrome.runtime.sendMessage({ type: "RESET_WIDGET_POSITION" });
+  if (res?.ok) {
+    showStatus("Widget position cleared. It will return to default on next load.", "success");
+  } else {
+    showStatus("Unable to reset widget position.", "error");
+  }
+}
+
 // ============================================================
 // Wire up UI events
 // ============================================================
@@ -153,8 +153,8 @@ modeRadios.forEach((radio) => radio.addEventListener("change", toggleFieldVisibi
 document.getElementById("save").addEventListener("click", save);
 document.getElementById("request-refresh").addEventListener("click", requestRefreshToken);
 document.getElementById("login").addEventListener("click", triggerLogin);
-document.getElementById("test-login").addEventListener("click", testLogin);
 document.getElementById("logout").addEventListener("click", logout);
+document.getElementById("reset-position").addEventListener("click", clearWidgetPosition);
 
 document.addEventListener("DOMContentLoaded", () => {
   toggleFieldVisibility();


### PR DESCRIPTION
## Summary
- Keep the widget compact while collapsed and add a reset hook to restore its default position
- Add an options-page control to clear the saved widget position
- Simplify the login controls and trigger a silent sign-in when the extension starts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2207e99c832eb9462daca878f3e2)